### PR TITLE
Add `shared_dimensions` to `OpenTelemetryDownstream`

### DIFF
--- a/src/benches/lightstep.rs
+++ b/src/benches/lightstep.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::{
     sync::{mpsc, Arc},
     time::Duration,
@@ -6,6 +7,7 @@ use std::{
 use criterion::Criterion;
 use hyper::{header::HeaderName, http::HeaderValue};
 
+use goodmetrics::types::{Dimension, Name};
 use goodmetrics::{
     allocator::pooled_metrics_allocator::PooledMetricsAllocator,
     downstream::{
@@ -60,7 +62,13 @@ pub fn lightstep_demo(criterion: &mut Criterion) {
             )
             .await
             .expect("i can make a channel to lightstep");
-            let mut downstream = OpenTelemetryDownstream::new(channel);
+            let mut downstream = OpenTelemetryDownstream::new(
+                channel,
+                Some(BTreeMap::from_iter(vec![(
+                    Name::from("name"),
+                    Dimension::from("value i guess"),
+                )])),
+            );
 
             let metrics_tasks = LocalSet::new();
 


### PR DESCRIPTION
The `GoodmetricsDownstream`  can be initialized with `shared_dimensions`, which are dimensions added to every metric.

This adds `shared_dimensions` to the `OpenTelemetryDownstream`. These are implemented as OpenTelemetry `Resource`s, which, from the [specification](https://opentelemetry.io/docs/reference/specification/resource/sdk/), are used for producing information about the entity producing telemetry - e.g.  instance names. In practice, `Resource`s are somewhat inconsistently implemented, but this seems to work as desired at least in Lightstep.
