### PR TITLE
Move noisy opentelementry logging to DEBUG

### DIFF
--- a/lib/src/downstream/opentelemetry_downstream.rs
+++ b/lib/src/downstream/opentelemetry_downstream.rs
@@ -92,7 +92,7 @@ impl OpenTelemetryDownstream {
                     };
                 }
                 Err(timeout) => {
-                    log::info!("no metrics activity: {timeout}");
+                    log::debug!("no metrics activity: {timeout}");
                     Delay::new(interval).await;
                 }
             }


### PR DESCRIPTION
This log statement can generate an entry every second, leading it to dominate otherwise sparse log files at the INFO level.

This change simply moves this to DEBUG, which is in line with the equivalent statement in the goodmetrics downstream.