### PR TITLE
improve contended latency

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
       run: |
         cargo --version
         cargo clippy --version
-        cargo clippy --all-targets --all-features -- -D warnings
+        cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used
     - name: Run tests
       run: cargo test --verbose
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -36,15 +36,15 @@ futures = { version = "0.3" }
 futures-batch = { version = "0.6" }
 futures-timer = { version = "3.0" }
 
-tonic = { version = "0.9", features = ["tls"] }
-prost = { version = "0.11" }
+tonic = { version = "0.10", features = ["tls"] }
+prost = { version = "0.12" }
 hyper = { version = "0.14" }
 tower = { version = "0.4" }
 tokio-rustls = { version = "0.24", features = ["dangerous_configuration"] }
 hyper-rustls = { version = "0.24", features = ["http2"] }
 
 object-pool = { version = "0.5" }
-ordered-float = { version = "3.7" }
+ordered-float = { version = "4.1" }
 
 [dev-dependencies]
 env_logger = { version = "0.10" }
@@ -53,4 +53,4 @@ tokio = { version = "1.21", features = ["rt-multi-thread"]}
 tokio-test = { version = "0.4" }
 webpki-roots = { version = "0" }
 
-criterion = { version = "0.4" }
+criterion = { version = "0.5" }

--- a/lib/benches/bench.rs
+++ b/lib/benches/bench.rs
@@ -4,4 +4,5 @@ mod benchmarks;
 
 criterion_main! {
     benchmarks::dimensions::benches,
+    benchmarks::aggregation::benches,
 }

--- a/lib/benches/benchmarks/aggregation.rs
+++ b/lib/benches/benchmarks/aggregation.rs
@@ -1,0 +1,63 @@
+use std::{
+    cmp::{max, min},
+    sync::mpsc::sync_channel,
+    time::{Duration, Instant},
+};
+
+use criterion::Criterion;
+use goodmetrics::{
+    allocator::always_new_metrics_allocator::AlwaysNewMetricsAllocator,
+    downstream::opentelemetry_downstream::create_preaggregated_opentelemetry_batch,
+    metrics_factory::{MetricsFactory, RecordingScope},
+    pipeline::{
+        aggregator::{Aggregator, DistributionMode},
+        stream_sink::StreamSink,
+    },
+};
+
+pub fn aggregation(criterion: &mut Criterion) {
+    // env_logger::builder().is_test(false).try_init().unwrap();
+
+    let mut group = criterion.benchmark_group("aggregation");
+    group.throughput(criterion::Throughput::Elements(1));
+
+    let (sink, receiver) = StreamSink::new();
+    let aggregator = Aggregator::new(receiver, DistributionMode::Histogram);
+    let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, StreamSink<_>> =
+        MetricsFactory::new(sink);
+    let (batch_sender, _r) = sync_channel(128);
+    aggregator
+        .spawn_aggregation_thread(
+            Duration::from_secs(1),
+            batch_sender,
+            create_preaggregated_opentelemetry_batch,
+        )
+        .expect("it should spawn");
+
+    for threads in [1, 2, 4, 8, 16] {
+        group.bench_function(format!("concurrency-{threads:02}"), |bencher| {
+            bencher.iter_custom(|iterations| {
+                let thread_count = max(1, min(threads, iterations));
+                let iterations_per_thread = iterations / thread_count;
+
+                let start = Instant::now();
+                std::thread::scope(|scope| {
+                    for _ in 0..thread_count {
+                        scope.spawn(|| {
+                            for i in 0..iterations_per_thread {
+                                let metrics = metrics_factory.record_scope("demo");
+                                let _scope = metrics.time("timed_delay");
+                                metrics.measurement("ran", 1);
+                                metrics.dimension("mod", i % 8);
+                            }
+                        });
+                    }
+                });
+
+                start.elapsed()
+            });
+        });
+    }
+}
+
+criterion::criterion_group!(benches, aggregation);

--- a/lib/benches/benchmarks/dimensions.rs
+++ b/lib/benches/benchmarks/dimensions.rs
@@ -7,6 +7,7 @@ use std::{
 use criterion::{black_box, Criterion};
 use goodmetrics::types::Dimension;
 
+#[allow(clippy::unwrap_used)]
 pub fn dimension_comparison(criterion: &mut Criterion) {
     env_logger::builder().is_test(false).try_init().unwrap();
 

--- a/lib/benches/benchmarks/mod.rs
+++ b/lib/benches/benchmarks/mod.rs
@@ -1,1 +1,2 @@
+pub mod aggregation;
 pub mod dimensions;

--- a/lib/src/allocator/always_new_metrics_allocator.rs
+++ b/lib/src/allocator/always_new_metrics_allocator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::RandomState, HashMap},
+    collections::{hash_map::RandomState, BTreeMap, HashMap},
     hash::BuildHasher,
     marker::PhantomData,
     time::Instant,
@@ -36,19 +36,19 @@ impl Default for AlwaysNewMetricsAllocator<RandomState> {
     }
 }
 
-impl<'a, TBuildHasher> MetricsAllocator<'a, Box<Metrics<TBuildHasher>>>
+impl<'a, TBuildHasher> MetricsAllocator<'a, Metrics<TBuildHasher>>
     for AlwaysNewMetricsAllocator<TBuildHasher>
 where
     TBuildHasher: BuildHasher + Default + 'a,
 {
     #[inline]
-    fn new_metrics(&self, metrics_name: impl Into<Name>) -> Box<Metrics<TBuildHasher>> {
-        Box::new(Metrics::new(
+    fn new_metrics(&self, metrics_name: impl Into<Name>) -> Metrics<TBuildHasher> {
+        Metrics::new(
             metrics_name,
             Instant::now(),
-            HashMap::with_hasher(Default::default()),
+            BTreeMap::new(),
             HashMap::with_hasher(Default::default()),
             MetricsBehavior::Default as u32,
-        ))
+        )
     }
 }

--- a/lib/src/allocator/mod.rs
+++ b/lib/src/allocator/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::hash_map::RandomState,
-    ops::{Deref, DerefMut},
-};
+use std::collections::hash_map::RandomState;
 
 use crate::{metrics::Metrics, types::Name};
 
@@ -11,12 +8,12 @@ pub mod returning_reference;
 pub mod pooled_metrics_allocator;
 
 pub trait MetricsRef<TBuildHasher = RandomState>:
-    Deref<Target = Metrics<TBuildHasher>> + DerefMut<Target = Metrics<TBuildHasher>>
+    AsRef<Metrics<TBuildHasher>> + AsMut<Metrics<TBuildHasher>>
 {
 }
 
 impl<T, TBuildHasher> MetricsRef<TBuildHasher> for T where
-    T: Deref<Target = Metrics<TBuildHasher>> + DerefMut<Target = Metrics<TBuildHasher>>
+    T: AsRef<Metrics<TBuildHasher>> + AsMut<Metrics<TBuildHasher>>
 {
 }
 

--- a/lib/src/allocator/pooled_metrics_allocator.rs
+++ b/lib/src/allocator/pooled_metrics_allocator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::RandomState, HashMap},
+    collections::{hash_map::RandomState, BTreeMap, HashMap},
     hash::BuildHasher,
     time::Instant,
 };
@@ -36,7 +36,7 @@ impl<T: BuildHasher + Default> PooledMetricsAllocator<T> {
         Metrics::new(
             "",
             Instant::now(),
-            HashMap::with_hasher(Default::default()),
+            BTreeMap::new(),
             HashMap::with_hasher(Default::default()),
             MetricsBehavior::Default as u32,
         )

--- a/lib/src/downstream/goodmetrics_downstream.rs
+++ b/lib/src/downstream/goodmetrics_downstream.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map, HashMap},
+    collections::HashMap,
     sync::mpsc::Receiver,
     time::{Duration, SystemTime},
 };
@@ -8,11 +8,11 @@ use futures_timer::Delay;
 
 use crate::{
     pipeline::{
-        aggregating_sink::DimensionedMeasurementsMap,
         aggregation::{
             online_tdigest::OnlineTdigest, statistic_set::StatisticSet, tdigest::Centroid,
             Aggregation,
         },
+        aggregator::{AggregatedMetricsMap, DimensionedMeasurementsMap},
         AbsorbDistribution,
     },
     proto::{
@@ -82,9 +82,10 @@ impl GoodmetricsDownstream {
 pub fn create_preaggregated_goodmetrics_batch(
     timestamp: SystemTime,
     duration: Duration,
-    batch: hash_map::Drain<'_, Name, DimensionedMeasurementsMap>,
+    batch: &mut AggregatedMetricsMap,
 ) -> Vec<Datum> {
     batch
+        .drain()
         .flat_map(|(name, dimensioned_measurements)| {
             as_datums(name, timestamp, duration, dimensioned_measurements)
         })

--- a/lib/src/pipeline/mod.rs
+++ b/lib/src/pipeline/mod.rs
@@ -7,10 +7,11 @@ use crate::types::{self, Distribution};
 
 use self::aggregation::{bucket::bucket_10_2_sigfigs, online_tdigest::OnlineTdigest};
 
-pub mod aggregating_sink;
 pub mod aggregation;
+pub mod aggregator;
 pub mod logging_sink;
 pub mod serializing_sink;
+pub mod stream_sink;
 
 pub trait Sink<Sunk> {
     fn accept(&self, to_sink: Sunk);

--- a/lib/src/pipeline/stream_sink.rs
+++ b/lib/src/pipeline/stream_sink.rs
@@ -1,0 +1,35 @@
+use std::sync::mpsc;
+
+use super::Sink;
+
+#[derive(Debug)]
+pub struct StreamSink<TMetricsRef> {
+    queue: mpsc::SyncSender<TMetricsRef>,
+}
+
+impl<TMetricsRef> Clone for StreamSink<TMetricsRef> {
+    fn clone(&self) -> Self {
+        Self {
+            queue: self.queue.clone(),
+        }
+    }
+}
+
+impl<TMetricsRef> StreamSink<TMetricsRef> {
+    pub fn new() -> (Self, mpsc::Receiver<TMetricsRef>) {
+        let (sender, receiver) = mpsc::sync_channel(1024);
+
+        (Self { queue: sender }, receiver)
+    }
+}
+
+impl<TMetricsRef> Sink<TMetricsRef> for StreamSink<TMetricsRef> {
+    fn accept(&self, to_sink: TMetricsRef) {
+        match self.queue.try_send(to_sink) {
+            Ok(_) => (),
+            Err(e) => {
+                log::debug!("could not send metrics: {e:?}");
+            }
+        }
+    }
+}

--- a/proto_generator/Cargo.toml
+++ b/proto_generator/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/kvc0/goodmetrics_rs"
 publish = false
 
 [lib]
+bench = false
 
 [build-dependencies]
 tonic-build = { version = "0.8", features = [] }


### PR DESCRIPTION
The AlwaysNewMetricsAllocator is faster, by a wide margin, in contended scenarios. By leaning into it a little, this pr gets nearly 18x more throughput with 8 cores (on a macbook), and still reaches 25% more throughput at 20% lower latency with 1 core.

Broadly, there are 2 big performance increases in here:

1) Moving metrics aggregation into a separate thread, via mpsc. This removed a Mutex that all Metrics drop()s had to go through. Now they just go into an mpsc SyncSender.

This change made it possible to change the AggregatingSink to just be an Aggregator. It is supposed to take a thread now, and just marshal metrics through aggregation. The threaded context is now over `self` as well, which means there is no need for a Mutex. Since we have `self` and SC from mpsc, we can blindly exploit `&mut self`. This makes metrics aggregation non-blocking and very lightweight.

By moving metrics aggregation to a dedicated thread and removing the Mutex from the drop path, direct consumers of the record_scope() api should see significantly lower latency and accordingly higher throughput.

2) Removing reference requirement from MetricsAllocator. This was an experiment, but it made a huge difference to record_scope() users. After the improvements in 1), this further refined another 10-20%, depending on contention. 10% would be worth the simplification, but in single-threaded use cases it improves as much as 20%. The cost here is that it is likely going to cause some churn.

These changes together are breaking. I may remove the pooled allocator in the future, but I'll leave it for the time being.

Concurrency level 8 comparison to main, record_scope measurement overhead:
![image](https://github.com/kvc0/goodmetrics_rs/assets/3454741/52315c8c-5cb6-43d6-ad2e-9d89964067af)
