### PR TITLE
Send batches more quickly

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -34,14 +34,14 @@ log =  { version = "0.4" }
 
 futures = { version = "0.3" }
 futures-batch = { version = "0.6" }
-futures-timer = { version = "3.0" }
 
-tonic = { version = "0.10", features = ["tls"] }
-prost = { version = "0.12" }
 hyper = { version = "0.14" }
-tower = { version = "0.4" }
-tokio-rustls = { version = "0.24", features = ["dangerous_configuration"] }
 hyper-rustls = { version = "0.24", features = ["http2"] }
+prost = { version = "0.12" }
+tokio = { version = "1.33" }
+tokio-rustls = { version = "0.24", features = ["dangerous_configuration"] }
+tonic = { version = "0.10", features = ["tls"] }
+tower = { version = "0.4" }
 
 object-pool = { version = "0.5" }
 ordered-float = { version = "4.1" }
@@ -49,7 +49,7 @@ ordered-float = { version = "4.1" }
 [dev-dependencies]
 env_logger = { version = "0.10" }
 test-log = { version = "0.2" }
-tokio = { version = "1.21", features = ["rt-multi-thread"]}
+tokio = { version = "1.33", features = ["rt-multi-thread"]}
 tokio-test = { version = "0.4" }
 webpki-roots = { version = "0" }
 

--- a/lib/src/downstream/goodmetrics_downstream.rs
+++ b/lib/src/downstream/goodmetrics_downstream.rs
@@ -4,8 +4,6 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use futures_timer::Delay;
-
 use crate::{
     pipeline::{
         aggregation::{
@@ -47,33 +45,33 @@ impl GoodmetricsDownstream {
     }
 
     pub async fn send_batches_forever(&mut self, receiver: Receiver<Vec<Datum>>) {
-        let interval = Duration::from_secs(1);
+        let mut interval = tokio::time::interval(Duration::from_millis(500));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
-            match receiver.try_recv() {
-                Ok(batch) => {
-                    let future = self.client.send_metrics(MetricsRequest {
+            interval.tick().await;
+            // Send as quickly as possible while there are more batches
+            while let Ok(batch) = receiver.try_recv() {
+                let result = self
+                    .client
+                    .send_metrics(MetricsRequest {
                         shared_dimensions: self.shared_dimensions.clone(),
                         metrics: batch,
-                    });
-                    match future.await {
-                        Ok(success) => {
-                            log::info!("sent metrics: {success:?}");
+                    })
+                    .await;
+                match result {
+                    Ok(success) => {
+                        log::info!("sent metrics: {success:?}");
+                    }
+                    Err(err) => {
+                        if !err.metadata().is_empty() {
+                            log::error!(
+                                "failed to send metrics: {err}. Metadata: {:?}",
+                                err.metadata()
+                            );
                         }
-                        Err(err) => {
-                            if !err.metadata().is_empty() {
-                                log::error!(
-                                    "failed to send metrics: {err}. Metadata: {:?}",
-                                    err.metadata()
-                                );
-                            }
-                            log::error!("failed to send metrics: {err:?}")
-                        }
-                    };
-                }
-                Err(timeout) => {
-                    log::debug!("no metrics activity: {timeout}");
-                    Delay::new(interval).await;
-                }
+                        log::error!("failed to send metrics: {err:?}")
+                    }
+                };
             }
         }
     }

--- a/lib/src/downstream/goodmetrics_downstream.rs
+++ b/lib/src/downstream/goodmetrics_downstream.rs
@@ -60,7 +60,7 @@ impl GoodmetricsDownstream {
                     .await;
                 match result {
                     Ok(success) => {
-                        log::info!("sent metrics: {success:?}");
+                        log::debug!("sent metrics: {success:?}");
                     }
                     Err(err) => {
                         if !err.metadata().is_empty() {

--- a/lib/src/downstream/opentelemetry_downstream.rs
+++ b/lib/src/downstream/opentelemetry_downstream.rs
@@ -81,7 +81,7 @@ impl OpenTelemetryDownstream {
                     .await;
                 match result {
                     Ok(success) => {
-                        log::info!("sent metrics: {success:?}");
+                        log::debug!("sent metrics: {success:?}");
                     }
                     Err(err) => {
                         if !err.metadata().is_empty() {

--- a/lib/src/downstream/opentelemetry_downstream.rs
+++ b/lib/src/downstream/opentelemetry_downstream.rs
@@ -5,8 +5,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use futures_timer::Delay;
-
 use crate::pipeline::{aggregation::histogram::Histogram, aggregator::AggregatedMetricsMap};
 use crate::proto::opentelemetry::resource::v1::Resource;
 use crate::{
@@ -55,11 +53,15 @@ impl OpenTelemetryDownstream {
     }
 
     pub async fn send_batches_forever(&mut self, receiver: Receiver<Vec<Metric>>) {
-        let interval = Duration::from_secs(1);
+        let mut interval = tokio::time::interval(Duration::from_millis(500));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
-            match receiver.try_recv() {
-                Ok(batch) => {
-                    let future = self.client.export(ExportMetricsServiceRequest {
+            interval.tick().await;
+            // Send as quickly as possible while there are more batches
+            while let Ok(batch) = receiver.try_recv() {
+                let result = self
+                    .client
+                    .export(ExportMetricsServiceRequest {
                         resource_metrics: vec![ResourceMetrics {
                             resource: self.shared_dimensions.as_ref().map(|dimensions| Resource {
                                 attributes: dimensions.clone(),
@@ -75,26 +77,22 @@ impl OpenTelemetryDownstream {
                                 metrics: batch,
                             }],
                         }],
-                    });
-                    match future.await {
-                        Ok(success) => {
-                            log::info!("sent metrics: {success:?}");
+                    })
+                    .await;
+                match result {
+                    Ok(success) => {
+                        log::info!("sent metrics: {success:?}");
+                    }
+                    Err(err) => {
+                        if !err.metadata().is_empty() {
+                            log::error!(
+                                "failed to send metrics: {err}. Metadata: {:?}",
+                                err.metadata()
+                            );
                         }
-                        Err(err) => {
-                            if !err.metadata().is_empty() {
-                                log::error!(
-                                    "failed to send metrics: {err}. Metadata: {:?}",
-                                    err.metadata()
-                                );
-                            }
-                            log::error!("failed to send metrics: {err:?}")
-                        }
-                    };
-                }
-                Err(timeout) => {
-                    log::debug!("no metrics activity: {timeout}");
-                    Delay::new(interval).await;
-                }
+                        log::error!("failed to send metrics: {err:?}")
+                    }
+                };
             }
         }
     }


### PR DESCRIPTION
If the upstream sends metrics quickly, there might be more than 1 downstream batch per second in aggregate. This change makes the sender tasks send batches (at concurrency=1) without delay as long as there are more batches immediately ready. Sleep only happens when there is nothing to send.

Also retire the futures_timer thread. This code uses tokio, and separating it out via a feature flag would be the right thing to do instead of making additional framework dependencies.