### PR TITLE
Add gauges

### DIFF
--- a/lib/benches/bench.rs
+++ b/lib/benches/bench.rs
@@ -3,6 +3,7 @@ use criterion::criterion_main;
 mod benchmarks;
 
 criterion_main! {
-    benchmarks::dimensions::benches,
     benchmarks::aggregation::benches,
+    benchmarks::dimensions::benches,
+    benchmarks::gauges::benches,
 }

--- a/lib/benches/benchmarks/gauges.rs
+++ b/lib/benches/benchmarks/gauges.rs
@@ -1,0 +1,51 @@
+use std::{
+    cmp::{max, min},
+    time::Instant,
+};
+
+use criterion::Criterion;
+use goodmetrics::{
+    allocator::always_new_metrics_allocator::AlwaysNewMetricsAllocator, metrics::Metrics,
+    metrics_factory::MetricsFactory, pipeline::Sink,
+};
+
+struct DropSink;
+impl Sink<Metrics> for DropSink {
+    fn accept(&self, _: Metrics) {}
+}
+
+pub fn gauges(criterion: &mut Criterion) {
+    // env_logger::builder().is_test(false).try_init().unwrap();
+
+    let mut group = criterion.benchmark_group("gauges");
+    group.throughput(criterion::Throughput::Elements(1));
+
+    let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, DropSink> =
+        MetricsFactory::new(DropSink);
+
+    let cached_gauge = metrics_factory.gauge("contention", "is okay");
+
+    for threads in [1, 2, 4, 8, 16] {
+        group.bench_function(format!("concurrency-{threads:02}"), |bencher| {
+            bencher.iter_custom(|iterations| {
+                let thread_count = max(1, min(threads, iterations));
+                let iterations_per_thread: i64 = (iterations / thread_count) as i64;
+
+                let start = Instant::now();
+                std::thread::scope(|scope| {
+                    for _ in 0..thread_count {
+                        scope.spawn(|| {
+                            for i in 0..iterations_per_thread {
+                                cached_gauge.observe(i % 8);
+                            }
+                        });
+                    }
+                });
+
+                start.elapsed()
+            });
+        });
+    }
+}
+
+criterion::criterion_group!(benches, gauges);

--- a/lib/benches/benchmarks/mod.rs
+++ b/lib/benches/benchmarks/mod.rs
@@ -1,2 +1,3 @@
 pub mod aggregation;
 pub mod dimensions;
+pub mod gauges;

--- a/lib/src/gauge.rs
+++ b/lib/src/gauge.rs
@@ -1,0 +1,74 @@
+use std::{
+    sync::atomic::{AtomicI64, AtomicU64},
+    time::Instant,
+};
+
+use crate::pipeline::aggregation::statistic_set::StatisticSet;
+
+/// A guage is a compromise for high throughput metrics. Sometimes you can't afford to
+/// allocate a Metrics object to record something, and you can let go of some detail
+/// to still be able to record some information. This is the compromise a Gauge allows.
+///
+/// Gauges are not transactional - you might chop a report just a little bit. If you're
+/// using a gauge, you probably require non-blocking behavior more than you require
+/// perfect happens-befores in your dashboard data.
+///
+/// Gauges have internal signed 64 bit integers for sum. This means you can definitely
+/// cause a Gauge to roll over if you record a lot of large numbers and/or report
+/// infrequently.
+pub struct StatisticSetGauge {
+    count: AtomicU64,
+    sum: AtomicI64,
+    min: AtomicI64,
+    max: AtomicI64,
+}
+
+const ORDERING: std::sync::atomic::Ordering = std::sync::atomic::Ordering::Relaxed;
+
+pub fn statistic_set_gauge() -> StatisticSetGauge {
+    StatisticSetGauge {
+        count: AtomicU64::new(0),
+        sum: AtomicI64::new(0),
+        min: AtomicI64::new(i64::MAX),
+        max: AtomicI64::new(i64::MIN),
+    }
+}
+
+impl StatisticSetGauge {
+    /// Observe a value of a gauge explicitly.
+    ///
+    /// This never blocks. Internal mutability is achieved via platform atomics.
+    #[inline]
+    pub fn observe(&self, value: impl Into<i64>) {
+        let value = value.into();
+        self.count.fetch_add(1, ORDERING);
+        self.sum.fetch_add(value, ORDERING);
+        self.min.fetch_min(value, ORDERING);
+        self.max.fetch_max(value, ORDERING);
+    }
+
+    /// Observe a value of a gauge explicitly. Note that this can roll over!
+    ///
+    /// This never blocks. Internal mutability is achieved via platform atomics.
+    #[inline]
+    pub fn observe_microseconds_since(&self, value: Instant) {
+        let value = value.elapsed().as_micros() as i64;
+        self.observe(value)
+    }
+}
+
+impl StatisticSetGauge {
+    pub fn reset(&self) -> Option<StatisticSet> {
+        let count = self.count.fetch_add(0, ORDERING);
+        if count == 0 {
+            return None;
+        }
+        let sum = self.sum.fetch_add(0, ORDERING);
+        Some(StatisticSet {
+            min: self.min.fetch_max(i64::MAX, ORDERING),
+            max: self.max.fetch_min(i64::MIN, ORDERING),
+            sum: self.sum.fetch_sub(sum, ORDERING),
+            count: self.count.fetch_sub(count, ORDERING),
+        })
+    }
+}

--- a/lib/src/gauge_group.rs
+++ b/lib/src/gauge_group.rs
@@ -1,0 +1,48 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Weak},
+};
+
+use crate::{
+    gauge::{self, StatisticSetGauge},
+    pipeline::aggregation::statistic_set::StatisticSet,
+    types::Name,
+};
+
+#[derive(Default)]
+pub struct GaugeGroup {
+    gauges: HashMap<Name, Weak<StatisticSetGauge>>,
+}
+
+impl GaugeGroup {
+    /// Create or retrieve a gauge.
+    pub fn gauge(&mut self, name: impl Into<Name>) -> Arc<StatisticSetGauge> {
+        let name = name.into();
+        match self.gauges.get(&name) {
+            Some(existing) => match existing.upgrade() {
+                Some(existing) => existing,
+                None => {
+                    let gauge: Arc<StatisticSetGauge> = Arc::new(gauge::statistic_set_gauge());
+                    self.gauges.insert(name, Arc::downgrade(&gauge));
+                    gauge
+                }
+            },
+            None => {
+                let gauge: Arc<StatisticSetGauge> = Arc::new(gauge::statistic_set_gauge());
+                self.gauges.insert(name, Arc::downgrade(&gauge));
+                gauge
+            }
+        }
+    }
+
+    pub fn reset(&mut self) -> impl Iterator<Item = (Name, StatisticSet)> + '_ {
+        self.gauges.retain(|_name, gauge| gauge.upgrade().is_some());
+
+        self.gauges.iter().filter_map(|(name, possible_gauge)| {
+            possible_gauge
+                .upgrade()
+                .and_then(|gauge| gauge.reset())
+                .map(|statistic_set| (name.to_owned(), statistic_set))
+        })
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -20,6 +20,8 @@
 
 pub mod allocator;
 pub mod downstream;
+pub mod gauge;
+pub mod gauge_group;
 pub mod metrics;
 pub mod metrics_factory;
 pub mod pipeline;


### PR DESCRIPTION
Gauges are StatisticSets that are periodically retrieved. There is no additional overhead for a Gauge beyond a few Relaxed memory order atomic operations. Under high contention on a Macbook the cost per observation of a number is around 0.25µs.

Metrics background tasks are getting to be more onerous. I will need to simplify the execution model at some point.