### PR TITLE
simplify background tasks with tokio

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,6 +35,8 @@ log =  { version = "0.4" }
 futures = { version = "0.3" }
 futures-batch = { version = "0.6" }
 
+bytes = { version = "1.5" }
+http-body = { version = "0.4" }
 hyper = { version = "0.14" }
 hyper-rustls = { version = "0.24", features = ["http2"] }
 prost = { version = "0.12" }

--- a/lib/benches/goodmetrics.rs
+++ b/lib/benches/goodmetrics.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use criterion::Criterion;
 use hyper::{header::HeaderName, http::HeaderValue};
@@ -45,12 +45,8 @@ pub fn goodmetrics_demo(criterion: &mut Criterion) {
                     HeaderValue::try_from(auth).expect("invalid authorization value"),
                 )),
             )
-            .await
             .expect("i can make a channel to goodmetrics");
-            let downstream = GoodmetricsDownstream::new(
-                channel,
-                HashMap::from_iter(vec![("application".to_string(), "bench".to_string())]),
-            );
+            let downstream = GoodmetricsDownstream::new(channel, [("application", "bench")]);
 
             join!(
                 aggregator.aggregate_metrics_forever(

--- a/lib/benches/lightstep.rs
+++ b/lib/benches/lightstep.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::{sync::mpsc, time::Duration};
+use std::time::Duration;
 
 use criterion::Criterion;
 use goodmetrics::allocator::always_new_metrics_allocator::AlwaysNewMetricsAllocator;
@@ -17,7 +17,8 @@ use goodmetrics::{
     metrics_factory::{MetricsFactory, RecordingScope},
     pipeline::aggregator::{Aggregator, DistributionMode},
 };
-use tokio::task::LocalSet;
+use tokio::join;
+use tokio::sync::mpsc;
 use tokio_rustls::rustls::{OwnedTrustAnchor, RootCertStore};
 
 #[allow(clippy::unwrap_used)]
@@ -27,16 +28,9 @@ pub fn lightstep_demo(criterion: &mut Criterion) {
     // Set up the bridge between application metrics threads and the metrics downstream thread
     let (sink, receiver) = StreamSink::new();
     let aggregator = Aggregator::new(receiver, DistributionMode::Histogram);
-    let (sender, receiver) = mpsc::sync_channel(128);
+    let (aggregated_batch_sender, receiver) = mpsc::channel(128);
 
     // Configure downstream metrics thread tasks
-    aggregator
-        .spawn_aggregation_thread(
-            Duration::from_secs(1),
-            sender,
-            create_preaggregated_opentelemetry_batch,
-        )
-        .expect("it should spawn");
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -69,7 +63,7 @@ pub fn lightstep_demo(criterion: &mut Criterion) {
             )
             .await
             .expect("i can make a channel to lightstep");
-            let mut downstream = OpenTelemetryDownstream::new(
+            let downstream = OpenTelemetryDownstream::new(
                 channel,
                 Some(BTreeMap::from_iter(vec![(
                     Name::from("name"),
@@ -77,13 +71,14 @@ pub fn lightstep_demo(criterion: &mut Criterion) {
                 )])),
             );
 
-            let metrics_tasks = LocalSet::new();
-
-            metrics_tasks.spawn_local(async move {
-                downstream.send_batches_forever(receiver).await;
-            });
-
-            metrics_tasks.await;
+            let _ = join!(
+                aggregator.aggregate_metrics_forever(
+                    Duration::from_secs(1),
+                    aggregated_batch_sender,
+                    create_preaggregated_opentelemetry_batch
+                ),
+                downstream.send_batches_forever(receiver),
+            );
         });
     });
 

--- a/lib/benches/lightstep.rs
+++ b/lib/benches/lightstep.rs
@@ -61,7 +61,6 @@ pub fn lightstep_demo(criterion: &mut Criterion) {
                     .expect("access token must be headerizable"),
                 )),
             )
-            .await
             .expect("i can make a channel to lightstep");
             let downstream = OpenTelemetryDownstream::new(
                 channel,

--- a/lib/src/downstream/channel_connection.rs
+++ b/lib/src/downstream/channel_connection.rs
@@ -10,6 +10,8 @@ use tokio_rustls::rustls::{client::ServerCertVerifier, ClientConfig, RootCertSto
 use tonic::body::BoxBody;
 use tower::{buffer::Buffer, util::BoxService, ServiceExt};
 
+use super::StdError;
+
 pub type ChannelType =
     Buffer<BoxService<Request<BoxBody>, Response<Body>, Error>, Request<BoxBody>>;
 
@@ -32,11 +34,11 @@ pub type ChannelType =
 /// }
 /// ;
 /// ```
-pub async fn get_channel<TrustFunction>(
+pub fn get_channel<TrustFunction>(
     endpoint: &str,
     tls_trust: TrustFunction,
     header: Option<(HeaderName, HeaderValue)>,
-) -> Result<ChannelType, Box<dyn std::error::Error>>
+) -> Result<ChannelType, StdError>
 where
     TrustFunction: FnOnce() -> Option<RootCertStore>,
 {
@@ -103,7 +105,6 @@ where
         })
         .service(https_client)
         .boxed();
-
     Ok(Buffer::new(service, 1024))
 }
 

--- a/lib/src/downstream/mod.rs
+++ b/lib/src/downstream/mod.rs
@@ -4,6 +4,8 @@ pub mod channel_connection;
 pub mod goodmetrics_downstream;
 pub mod opentelemetry_downstream;
 
+pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 pub trait EpochTime {
     fn nanos_since_epoch(&self) -> u64;
 }

--- a/lib/src/metrics_factory.rs
+++ b/lib/src/metrics_factory.rs
@@ -25,8 +25,8 @@ use crate::{
 /// Example complete preaggregated metrics pipeline setup, with gauge support:
 ///
 /// ```
-/// # #[tokio::main]
-/// # async fn main() {
+/// # let runtime = tokio::runtime::Builder::new_current_thread().build().expect("runtime can be built");
+/// # runtime.block_on(async {
 /// use goodmetrics::allocator::always_new_metrics_allocator::AlwaysNewMetricsAllocator;
 /// use goodmetrics::downstream::goodmetrics_downstream::create_preaggregated_goodmetrics_batch;
 /// use goodmetrics::downstream::goodmetrics_downstream::GoodmetricsDownstream;
@@ -72,7 +72,7 @@ use crate::{
 /// );
 ///
 /// // Now you use your metrics_factory and clone the Arc around wherever you need it
-/// # }
+/// # });
 /// ```
 pub struct MetricsFactory<TMetricsAllocator, TSink> {
     allocator: TMetricsAllocator,

--- a/lib/src/pipeline/stream_sink.rs
+++ b/lib/src/pipeline/stream_sink.rs
@@ -1,10 +1,10 @@
-use std::sync::mpsc;
+use tokio::sync::mpsc;
 
 use super::Sink;
 
 #[derive(Debug)]
 pub struct StreamSink<TMetricsRef> {
-    queue: mpsc::SyncSender<TMetricsRef>,
+    queue: mpsc::Sender<TMetricsRef>,
 }
 
 impl<TMetricsRef> Clone for StreamSink<TMetricsRef> {
@@ -17,7 +17,7 @@ impl<TMetricsRef> Clone for StreamSink<TMetricsRef> {
 
 impl<TMetricsRef> StreamSink<TMetricsRef> {
     pub fn new() -> (Self, mpsc::Receiver<TMetricsRef>) {
-        let (sender, receiver) = mpsc::sync_channel(1024);
+        let (sender, receiver) = mpsc::channel(1024);
 
         (Self { queue: sender }, receiver)
     }


### PR DESCRIPTION
Previously goodmetrics_rs had been tokio-agnostic, but it's cleaner, easier, faster, and more obvious how to use it this way.