### PR TITLE
Remove internal mutability, add arc_allocator

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,6 +35,7 @@ log =  { version = "0.4" }
 futures = { version = "0.3" }
 futures-batch = { version = "0.6" }
 
+arc-swap = { version = "1.6" }
 bytes = { version = "1.5" }
 http-body = { version = "0.4" }
 hyper = { version = "0.14" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,7 +35,6 @@ log =  { version = "0.4" }
 futures = { version = "0.3" }
 futures-batch = { version = "0.6" }
 
-arc-swap = { version = "1.6" }
 bytes = { version = "1.5" }
 http-body = { version = "0.4" }
 hyper = { version = "0.14" }

--- a/lib/benches/benchmarks/aggregation.rs
+++ b/lib/benches/benchmarks/aggregation.rs
@@ -48,7 +48,7 @@ pub fn aggregation(criterion: &mut Criterion) {
                     for _ in 0..thread_count {
                         scope.spawn(|| {
                             for i in 0..iterations_per_thread {
-                                let metrics = metrics_factory.record_scope("demo");
+                                let mut metrics = metrics_factory.record_scope("demo");
                                 let _scope = metrics.time("timed_delay");
                                 metrics.measurement("ran", 1);
                                 metrics.dimension("mod", i % 8);

--- a/lib/benches/goodmetrics.rs
+++ b/lib/benches/goodmetrics.rs
@@ -71,7 +71,7 @@ pub fn goodmetrics_demo(criterion: &mut Criterion) {
         bencher.iter(move || {
             i += 1;
 
-            let metrics = metrics_factory.record_scope("demo");
+            let mut metrics = metrics_factory.record_scope("demo");
             let _scope = metrics.time("timed_delay");
             metrics.measurement("ran", 1);
             metrics.dimension("mod", i % 8);

--- a/lib/benches/lightstep.rs
+++ b/lib/benches/lightstep.rs
@@ -96,7 +96,7 @@ pub fn lightstep_demo(criterion: &mut Criterion) {
         bencher.iter(|| {
             i += 1;
 
-            let metrics = metrics_factory.record_scope("demo");
+            let mut metrics = metrics_factory.record_scope("demo");
             let _scope = metrics.time("timed_delay");
             metrics.measurement("ran", 1);
             metrics.dimension("mod", i % 8);

--- a/lib/benches/lightstep.rs
+++ b/lib/benches/lightstep.rs
@@ -44,9 +44,12 @@ pub fn lightstep_demo(criterion: &mut Criterion) {
                     store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(
                         |trust_anchor| {
                             OwnedTrustAnchor::from_subject_spki_name_constraints(
-                                trust_anchor.subject,
-                                trust_anchor.spki,
-                                trust_anchor.name_constraints,
+                                trust_anchor.subject.to_vec(),
+                                trust_anchor.subject_public_key_info.to_vec(),
+                                trust_anchor
+                                    .name_constraints
+                                    .as_ref()
+                                    .map(|der| der.to_vec()),
                             )
                         },
                     ));

--- a/lib/src/allocator/always_new_metrics_allocator.rs
+++ b/lib/src/allocator/always_new_metrics_allocator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::RandomState, BTreeMap, HashMap},
+    collections::{hash_map::RandomState, HashMap},
     hash::BuildHasher,
     marker::PhantomData,
     time::Instant,
@@ -46,8 +46,9 @@ where
         Metrics::new(
             metrics_name,
             Instant::now(),
-            BTreeMap::new(),
             HashMap::with_hasher(Default::default()),
+            HashMap::with_hasher(Default::default()),
+            Vec::new(),
             MetricsBehavior::Default as u32,
         )
     }

--- a/lib/src/allocator/arc_allocator.rs
+++ b/lib/src/allocator/arc_allocator.rs
@@ -102,7 +102,7 @@ where
     }
 }
 
-pub struct CachedMetrics<TBuildHasher>
+pub struct CachedMetrics<TBuildHasher = RandomState>
 where
     TBuildHasher: BuildHasher + Default + Send + 'static,
 {

--- a/lib/src/allocator/arc_allocator.rs
+++ b/lib/src/allocator/arc_allocator.rs
@@ -27,7 +27,14 @@ struct AllocatorState<TBuildHasher: Send> {
     cache_clock: AtomicUsize,
 }
 
-pub type ArcMetrics<TBuildHasher> = Arc<Metrics<TBuildHasher>>;
+impl<TBuildHasher> Default for ArcAllocator<TBuildHasher>
+where
+    TBuildHasher: BuildHasher + Default + Send + 'static,
+{
+    fn default() -> Self {
+        Self::new(1024)
+    }
+}
 
 impl<TBuildHasher> ArcAllocator<TBuildHasher>
 where

--- a/lib/src/allocator/arc_allocator.rs
+++ b/lib/src/allocator/arc_allocator.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::{
     cmp::max,
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     hash::BuildHasher,
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
@@ -71,8 +71,9 @@ where
             None => Metrics::new(
                 metrics_name,
                 Instant::now(),
-                BTreeMap::new(),
                 HashMap::with_hasher(Default::default()),
+                HashMap::with_hasher(Default::default()),
+                Vec::new(),
                 MetricsBehavior::Default as u32,
             ),
         };

--- a/lib/src/allocator/arc_allocator.rs
+++ b/lib/src/allocator/arc_allocator.rs
@@ -1,0 +1,153 @@
+use crate::{
+    metrics::{Metrics, MetricsBehavior},
+    types::Name,
+};
+use std::{
+    cmp::max,
+    collections::{BTreeMap, HashMap},
+    hash::BuildHasher,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+    sync::{atomic::AtomicUsize, Arc, Mutex},
+    time::Instant,
+};
+
+use super::MetricsAllocator;
+
+/// A metrics allocator that prioritizes reusing Metrics objects, but with a gentler
+/// Borrow Checker constraint. References are owned, so it's easier to pass them
+/// around.
+#[derive(Clone)]
+pub struct ArcAllocator<TBuildHasher: Send> {
+    state: Arc<AllocatorState<TBuildHasher>>,
+}
+
+struct AllocatorState<TBuildHasher: Send> {
+    metrics_cache: [Mutex<Vec<Metrics<TBuildHasher>>>; 8],
+    cache_clock: AtomicUsize,
+}
+
+pub type ArcMetrics<TBuildHasher> = Arc<Metrics<TBuildHasher>>;
+
+impl<TBuildHasher> ArcAllocator<TBuildHasher>
+where
+    TBuildHasher: BuildHasher + Default + Send + 'static,
+{
+    pub fn new(cache_size: usize) -> Self {
+        Self {
+            state: Arc::new(AllocatorState {
+                metrics_cache: [(); 8]
+                    .map(|_| Mutex::new(Vec::with_capacity(max(16, cache_size / 8)))),
+                cache_clock: Default::default(),
+            }),
+        }
+    }
+}
+
+impl<'a, TBuildHasher: Send> MetricsAllocator<'a, CachedMetrics<TBuildHasher>>
+    for ArcAllocator<TBuildHasher>
+where
+    TBuildHasher: BuildHasher + Default + 'a,
+{
+    #[inline]
+    fn new_metrics(&self, metrics_name: impl Into<Name>) -> CachedMetrics<TBuildHasher> {
+        let slot = self
+            .state
+            .cache_clock
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % self.state.metrics_cache.len();
+        let metrics = self.state.metrics_cache[slot]
+            .lock()
+            .expect("local mutex")
+            .pop();
+        let metrics = match metrics {
+            Some(mut reused_metrics) => {
+                reused_metrics.restart();
+                reused_metrics.metrics_name = metrics_name.into();
+                reused_metrics.start_time = Instant::now();
+                reused_metrics.behaviors = MetricsBehavior::Default as u32;
+                reused_metrics
+            }
+            None => Metrics::new(
+                metrics_name,
+                Instant::now(),
+                BTreeMap::new(),
+                HashMap::with_hasher(Default::default()),
+                MetricsBehavior::Default as u32,
+            ),
+        };
+        CachedMetrics {
+            allocator: self.state.clone(),
+            metrics: ManuallyDrop::new(metrics),
+        }
+    }
+}
+
+impl<TBuildHasher> AllocatorState<TBuildHasher>
+where
+    TBuildHasher: BuildHasher + Default + Send + 'static,
+{
+    #[inline]
+    fn return_instance(&self, mut metrics: Metrics<TBuildHasher>) {
+        let slot = self
+            .cache_clock
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % self.metrics_cache.len();
+        let mut cache = self.metrics_cache[slot].lock().expect("local mutex");
+        if cache.len() < cache.capacity() {
+            metrics.restart();
+            cache.push(metrics)
+        }
+    }
+}
+
+pub struct CachedMetrics<TBuildHasher>
+where
+    TBuildHasher: BuildHasher + Default + Send + 'static,
+{
+    allocator: Arc<AllocatorState<TBuildHasher>>,
+    metrics: ManuallyDrop<Metrics<TBuildHasher>>,
+}
+
+impl<TBuildHasher> Drop for CachedMetrics<TBuildHasher>
+where
+    TBuildHasher: BuildHasher + Default + Send + 'static,
+{
+    fn drop(&mut self) {
+        // SAFETY: The referent is extracted on this line and the manuallydropped is dropped without further use
+        let metrics: Metrics<TBuildHasher> = unsafe { ManuallyDrop::take(&mut self.metrics) };
+        self.allocator.return_instance(metrics);
+    }
+}
+
+impl<TBuildHasher: BuildHasher + Default + Send> Deref for CachedMetrics<TBuildHasher> {
+    type Target = Metrics<TBuildHasher>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.metrics
+    }
+}
+
+impl<TBuildHasher: BuildHasher + Default + Send> DerefMut for CachedMetrics<TBuildHasher> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.metrics
+    }
+}
+
+impl<TBuildHasher: BuildHasher + Default + Send> AsMut<Metrics<TBuildHasher>>
+    for CachedMetrics<TBuildHasher>
+{
+    fn as_mut(&mut self) -> &mut Metrics<TBuildHasher> {
+        &mut self.metrics
+    }
+}
+
+impl<TBuildHasher: BuildHasher + Default + Send> AsRef<Metrics<TBuildHasher>>
+    for CachedMetrics<TBuildHasher>
+{
+    fn as_ref(&self) -> &Metrics<TBuildHasher> {
+        &self.metrics
+    }
+}

--- a/lib/src/allocator/arc_allocator.rs
+++ b/lib/src/allocator/arc_allocator.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::{
     cmp::max,
-    collections::HashMap,
+    collections::{hash_map::RandomState, HashMap},
     hash::BuildHasher,
     mem::take,
     ops::{Deref, DerefMut},
@@ -18,7 +18,7 @@ use super::MetricsAllocator;
 /// Borrow Checker constraint. References are owned, so it's easier to pass them
 /// around.
 #[derive(Clone)]
-pub struct ArcAllocator<TBuildHasher: Send> {
+pub struct ArcAllocator<TBuildHasher: Send = RandomState> {
     state: Arc<AllocatorState<TBuildHasher>>,
 }
 

--- a/lib/src/allocator/mod.rs
+++ b/lib/src/allocator/mod.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::RandomState;
 use crate::{metrics::Metrics, types::Name};
 
 pub mod always_new_metrics_allocator;
+pub mod arc_allocator;
 pub mod returning_reference;
 
 pub mod pooled_metrics_allocator;

--- a/lib/src/allocator/pooled_metrics_allocator.rs
+++ b/lib/src/allocator/pooled_metrics_allocator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::RandomState, BTreeMap, HashMap},
+    collections::{hash_map::RandomState, HashMap},
     hash::BuildHasher,
     time::Instant,
 };
@@ -36,8 +36,9 @@ impl<T: BuildHasher + Default> PooledMetricsAllocator<T> {
         Metrics::new(
             "",
             Instant::now(),
-            BTreeMap::new(),
             HashMap::with_hasher(Default::default()),
+            HashMap::with_hasher(Default::default()),
+            Vec::new(),
             MetricsBehavior::Default as u32,
         )
     }

--- a/lib/src/downstream/channel_connection.rs
+++ b/lib/src/downstream/channel_connection.rs
@@ -24,9 +24,9 @@ pub type ChannelType =
 ///     store.add_server_trust_anchors(
 ///         webpki_roots::TLS_SERVER_ROOTS.iter().map(|trust_anchor| {
 ///             tokio_rustls::rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-///                 trust_anchor.subject,
-///                 trust_anchor.spki,
-///                 trust_anchor.name_constraints
+///                 trust_anchor.subject.to_vec(),
+///                 trust_anchor.subject_public_key_info.to_vec(),
+///                 trust_anchor.name_constraints.as_ref().map(|der| der.to_vec())
 ///             )
 ///         })
 ///     );

--- a/lib/src/metrics.rs
+++ b/lib/src/metrics.rs
@@ -1,11 +1,12 @@
 use std::{
-    collections::{self, BTreeMap, HashMap},
+    collections::{self, HashMap},
     fmt::Display,
     hash::BuildHasher,
-    mem::ManuallyDrop,
-    sync::Mutex,
+    sync::{atomic::AtomicUsize, Arc},
     time::Instant,
 };
+
+use futures::channel::oneshot;
 
 use crate::types::{Dimension, Distribution, Measurement, Name, Observation};
 
@@ -41,9 +42,57 @@ pub enum MetricsBehavior {
 pub struct Metrics<TBuildHasher = collections::hash_map::RandomState> {
     pub(crate) metrics_name: Name,
     pub(crate) start_time: Instant,
-    dimensions: Mutex<BTreeMap<Name, Dimension>>,
-    measurements: Mutex<HashMap<Name, Measurement, TBuildHasher>>,
+    dimensions: HashMap<Name, Dimension, TBuildHasher>,
+    measurements: HashMap<Name, Measurement, TBuildHasher>,
+    dimension_guards: Vec<OverrideDimension>,
     pub(crate) behaviors: u32,
+}
+
+#[derive(Debug)]
+pub struct DimensionGuard {
+    override_sender: oneshot::Sender<Dimension>,
+}
+impl DimensionGuard {
+    fn new(name: Name, default: Dimension) -> (Self, OverrideDimension) {
+        let (override_sender, override_receiver) = oneshot::channel();
+        (Self {
+            override_sender,
+        }, OverrideDimension {
+            name,
+            default,
+            override_receiver,
+        })
+    }
+
+    pub fn set(self, dimension: impl Into<Dimension>) {
+        match self.override_sender.send(dimension.into()) {
+            Ok(_) => (),
+            Err(e) => log::debug!("dimension arrived too late: {e:?}"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct OverrideDimension {
+    name: Name,
+    default: Dimension,
+    override_receiver: oneshot::Receiver<Dimension>,
+}
+
+impl OverrideDimension {
+    /// Consume the dimension. If it hasn't been set by now, you get the default value.
+    pub fn redeem(mut self) -> (Name, Dimension) {
+        (
+            self.name,
+            match self.override_receiver.try_recv() {
+                Ok(option) => match option {
+                    Some(overriden) => overriden,
+                    None => self.default,
+                },
+                Err(_) => self.default,
+            }
+        )
+    }
 }
 
 impl AsRef<Metrics> for Metrics {
@@ -79,58 +128,21 @@ where
 {
     /// Record a dimension name and value pair - last write per metrics object wins!
     #[inline]
-    pub fn dimension(&self, name: impl Into<Name>, value: impl Into<Dimension>) {
-        let mut mutable_dimensions = self.dimensions.lock().expect("Mutex was unable to lock!");
-        mutable_dimensions.insert(name.into(), value.into());
-    }
-
-    /// Record a dimension name and value pair - last write per metrics object wins!
-    /// Prefer this when you have mut on Metrics. It's faster!
-    #[inline]
-    pub fn dimension_mut(&mut self, name: impl Into<Name>, value: impl Into<Dimension>) {
-        let mutable_dimensions = self
-            .dimensions
-            .get_mut()
-            .expect("Mutex was unable to lock!");
-        mutable_dimensions.insert(name.into(), value.into());
+    pub fn dimension(&mut self, name: impl Into<Name>, value: impl Into<Dimension>) {
+        self.dimensions.insert(name.into(), value.into());
     }
 
     /// Record a measurement name and value pair - last write per metrics object wins!
     #[inline]
-    pub fn measurement(&self, name: impl Into<Name>, value: impl Into<Observation>) {
-        let mut mutable_measurements = self.measurements.lock().expect("Mutex was unable to lock!");
-        mutable_measurements.insert(name.into(), Measurement::Observation(value.into()));
-    }
-
-    /// Record a measurement name and value pair - last write per metrics object wins!
-    /// Prefer this when you have mut on Metrics. It's faster!
-    #[inline]
-    pub fn measurement_mut(&mut self, name: impl Into<Name>, value: impl Into<Observation>) {
-        let mutable_measurements = self
-            .measurements
-            .get_mut()
-            .expect("Mutex was unable to lock!");
-        mutable_measurements.insert(name.into(), Measurement::Observation(value.into()));
+    pub fn measurement(&mut self, name: impl Into<Name>, value: impl Into<Observation>) {
+        self.measurements.insert(name.into(), Measurement::Observation(value.into()));
     }
 
     /// Record a distribution name and value pair - last write per metrics object wins!
     /// Check out t-digests if you're using a goodmetrics + timescale downstream.
     #[inline]
-    pub fn distribution(&self, name: impl Into<Name>, value: impl Into<Distribution>) {
-        let mut mutable_measurements = self.measurements.lock().expect("Mutex was unable to lock!");
-        mutable_measurements.insert(name.into(), Measurement::Distribution(value.into()));
-    }
-
-    /// Record a distribution name and value pair - last write per metrics object wins!
-    /// Prefer this when you have mut on Metrics. It's faster!
-    /// Check out t-digests if you're using a goodmetrics + timescale downstream.
-    #[inline]
-    pub fn distribution_mut(&mut self, name: impl Into<Name>, value: impl Into<Distribution>) {
-        let mutable_measurements = self
-            .measurements
-            .get_mut()
-            .expect("Mutex was unable to lock!");
-        mutable_measurements.insert(name.into(), Measurement::Distribution(value.into()));
+    pub fn distribution(&mut self, name: impl Into<Name>, value: impl Into<Distribution>) {
+        self.measurements.insert(name.into(), Measurement::Distribution(value.into()));
     }
 
     /// Record a time distribution in nanoseconds.
@@ -138,8 +150,17 @@ where
     ///
     /// The returned Timer is a scope guard.
     #[inline]
-    pub fn time(&self, timer_name: impl Into<Name>) -> Timer<'_, TBuildHasher> {
-        Timer::new(self, timer_name)
+    pub fn time(&mut self, timer_name: impl Into<Name>) -> Timer {
+        let timer = Arc::new(AtomicUsize::new(0));
+        self.measurements.insert(timer_name.into(), Measurement::Distribution(Distribution::Timer { nanos: timer.clone() }));
+        Timer::new(timer)
+    }
+
+    /// A dimension that you set a default for in case you drop early or something.
+    pub fn guarded_dimension(&mut self, name: impl Into<Name>, default: impl Into<Dimension>) -> DimensionGuard {
+        let (guard, dimension) = DimensionGuard::new(name.into(), default.into());
+        self.dimension_guards.push(dimension);
+        guard
     }
 
     /// Name of the metrics you passed in when you created it.
@@ -149,17 +170,12 @@ where
     }
 
     /// Clear the structure in preparation for reuse without allocation.
+    /// You still need to set the right behaviors and start times.
     #[inline]
     pub fn restart(&mut self) {
-        self.start_time = Instant::now();
-        self.dimensions
-            .get_mut()
-            .expect("Mutex was unable to lock!")
-            .clear();
-        self.measurements
-            .get_mut()
-            .expect("Mutex was unable to lock!")
-            .clear();
+        self.dimensions.clear();
+        self.measurements.clear();
+        self.dimension_guards.clear();
     }
 
     /// Do not report this metrics instance.
@@ -205,16 +221,18 @@ where
     pub fn new(
         name: impl Into<Name>,
         start_time: Instant,
-        dimensions: BTreeMap<Name, Dimension>,
+        dimensions: HashMap<Name, Dimension, TBuildHasher>,
         measurements: HashMap<Name, Measurement, TBuildHasher>,
+        dimension_guards: Vec<OverrideDimension>,
         behaviors: u32,
     ) -> Self {
         Self {
             metrics_name: name.into(),
             start_time,
-            dimensions: Mutex::new(dimensions),
-            measurements: Mutex::new(measurements),
+            dimensions,
+            measurements,
             behaviors,
+            dimension_guards,
         }
     }
 
@@ -223,16 +241,16 @@ where
     pub fn drain(
         &mut self,
     ) -> (
-        &mut BTreeMap<Name, Dimension>,
+        &mut HashMap<Name, Dimension, TBuildHasher>,
         &mut HashMap<Name, Measurement, TBuildHasher>,
     ) {
+        while let Some(d) = self.dimension_guards.pop() {
+            let (name, value) = d.redeem();
+            self.dimension(name, value);
+        }
         (
-            self.dimensions
-                .get_mut()
-                .expect("Mutex was unable to lock!"),
-            self.measurements
-                .get_mut()
-                .expect("Mutex was unable to lock!"),
+            &mut self.dimensions,
+            &mut self.measurements,
         )
     }
 }
@@ -240,36 +258,25 @@ where
 /// Scope guard for recording nanoseconds into a Metrics.
 /// Starts recording when you create it.
 /// Stops recording and puts its measurement into the Metrics as a distribution when you drop it.
-pub struct Timer<'timer, TBuildHasher>
-where
-    TBuildHasher: BuildHasher,
+pub struct Timer
 {
     start_time: Instant,
-    metrics: &'timer Metrics<TBuildHasher>,
-    name: ManuallyDrop<Name>,
+    timer: Arc<AtomicUsize>,
 }
 
-impl<'timer, TBuildHasher> Drop for Timer<'timer, TBuildHasher>
-where
-    TBuildHasher: BuildHasher,
+impl Drop for Timer
 {
     fn drop(&mut self) {
-        self.metrics.distribution(
-            unsafe { ManuallyDrop::take(&mut self.name) },
-            self.start_time.elapsed(),
-        )
+        self.timer.store(self.start_time.elapsed().as_nanos() as usize, std::sync::atomic::Ordering::Release);
     }
 }
 
-impl<'timer, TBuildHasher> Timer<'timer, TBuildHasher>
-where
-    TBuildHasher: BuildHasher,
+impl Timer
 {
-    pub fn new(metrics: &'timer Metrics<TBuildHasher>, timer_name: impl Into<Name>) -> Self {
+    pub fn new(timer: Arc<AtomicUsize>) -> Self {
         Self {
             start_time: Instant::now(),
-            metrics,
-            name: ManuallyDrop::new(timer_name.into()),
+            timer,
         }
     }
 }
@@ -277,11 +284,11 @@ where
 #[cfg(test)]
 mod test {
     use std::{
-        collections::{BTreeMap, HashMap},
+        collections::HashMap,
         time::Instant,
     };
 
-    use crate::metrics::{Metrics, Timer};
+    use crate::metrics::Metrics;
 
     fn is_send(_o: impl Send) {}
     fn is_sync(_o: impl Sync) {}
@@ -291,8 +298,9 @@ mod test {
         let metrics = Metrics::new(
             "name",
             Instant::now(),
-            BTreeMap::from([]),
             HashMap::from([]),
+            HashMap::from([]),
+            Vec::new(),
             0,
         );
         is_send(metrics);
@@ -300,8 +308,9 @@ mod test {
         let metrics = Metrics::new(
             "name",
             Instant::now(),
-            BTreeMap::from([]),
             HashMap::from([]),
+            HashMap::from([]),
+            Vec::new(),
             0,
         );
         is_sync(metrics);
@@ -309,16 +318,17 @@ mod test {
 
     #[test_log::test]
     fn test_timer() {
-        let metrics = Metrics::new(
+        let mut metrics = Metrics::new(
             "name",
             Instant::now(),
-            BTreeMap::from([]),
             HashMap::from([]),
+            HashMap::from([]),
+            Vec::new(),
             0,
         );
-        let timer_1 = Timer::new(&metrics, "t1");
+        let timer_1 = metrics.time("t1");
         is_send(timer_1);
-        let timer_1 = Timer::new(&metrics, "t1");
+        let timer_1 = metrics.time("t1");
         is_sync(timer_1);
     }
 }

--- a/lib/src/metrics_factory.rs
+++ b/lib/src/metrics_factory.rs
@@ -163,7 +163,7 @@ where
 
     // You should consider using record_scope() instead.
     #[inline]
-    fn emit(&self, metrics: TMetricsRef) {
+    fn emit(&self, mut metrics: TMetricsRef) {
         if metrics.as_ref().has_behavior(MetricsBehavior::Suppress) {
             return;
         }
@@ -172,7 +172,7 @@ where
             .has_behavior(MetricsBehavior::SuppressTotalTime)
         {
             let elapsed = metrics.as_ref().start_time.elapsed();
-            metrics.as_ref().distribution("totaltime", elapsed);
+            metrics.as_mut().distribution("totaltime", elapsed);
         }
 
         self.sink.accept(metrics)
@@ -340,7 +340,7 @@ mod test {
     fn logging_metrics_factory() {
         let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, LoggingSink> =
             MetricsFactory::new(LoggingSink::default());
-        let metrics = metrics_factory.record_scope("test");
+        let mut metrics = metrics_factory.record_scope("test");
         // Dimension the scoped metrics
         metrics.dimension("some dimension", "a dim");
 
@@ -364,7 +364,7 @@ mod test {
             &[MetricsBehavior::Default],
             AlwaysNewMetricsAllocator::default(),
         );
-        let metrics = metrics_factory.record_scope("test");
+        let mut metrics = metrics_factory.record_scope("test");
         // Dimension the scoped metrics
         metrics.dimension("some dimension", "a dim");
 
@@ -384,7 +384,7 @@ mod test {
         #[allow(clippy::redundant_clone)]
         let cloned = metrics_factory.clone();
         {
-            let metrics = metrics_factory.record_scope("test");
+            let mut metrics = metrics_factory.record_scope("test");
             metrics.dimension("some dimension", "a dim");
         }
 
@@ -404,7 +404,7 @@ mod test {
         #[allow(clippy::redundant_clone)]
         let cloned = metrics_factory.clone();
         {
-            let metrics = metrics_factory.record_scope("test");
+            let mut metrics = metrics_factory.record_scope("test");
             metrics.dimension("some dimension", "a dim");
         }
 

--- a/lib/src/pipeline/aggregator.rs
+++ b/lib/src/pipeline/aggregator.rs
@@ -217,7 +217,8 @@ where
             match dimensioned_measurements_map.get_mut(&self.cached_position) {
                 Some(map) => map,
                 None => {
-                    dimensioned_measurements_map.insert(self.cached_position.clone(), Default::default());
+                    dimensioned_measurements_map
+                        .insert(self.cached_position.clone(), Default::default());
                     dimensioned_measurements_map
                         .get_mut(&self.cached_position)
                         .expect("I just inserted this 1 line above")

--- a/lib/src/pipeline/mod.rs
+++ b/lib/src/pipeline/mod.rs
@@ -71,7 +71,7 @@ impl AbsorbDistribution for HashMap<i64, u64> {
                 self.entry(bucket_10_2_sigfigs(v as i64))
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
-            },
+            }
         };
     }
 }

--- a/lib/src/pipeline/mod.rs
+++ b/lib/src/pipeline/mod.rs
@@ -66,6 +66,12 @@ impl AbsorbDistribution for HashMap<i64, u64> {
                         .or_insert(1);
                 });
             }
+            types::Distribution::Timer { nanos } => {
+                let v = nanos.load(std::sync::atomic::Ordering::Acquire);
+                self.entry(bucket_10_2_sigfigs(v as i64))
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+            },
         };
     }
 }
@@ -79,6 +85,9 @@ impl AbsorbDistribution for OnlineTdigest {
             types::Distribution::U32(i) => self.observe_mut(i),
             types::Distribution::Collection(collection) => {
                 collection.iter().for_each(|i| self.observe_mut(*i as f64));
+            }
+            types::Distribution::Timer { nanos } => {
+                self.observe_mut(nanos.load(std::sync::atomic::Ordering::Acquire) as f64)
             }
         };
     }

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, sync::Arc, time::Duration};
+use std::{fmt::Display, sync::{Arc, atomic::AtomicUsize}, time::Duration};
 
 /// The value part of a dimension's key/value pair.
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
@@ -103,6 +103,16 @@ pub enum Distribution {
     // Also, this unconditionally uses the global allocator.
     // PR to plumb the allocator type out would be welcome.
     Collection(Vec<i64>),
+    // A helper for recording a distribution of time. This is
+    // shared by a Timer with a Drop implementation and the
+    // Metrics object for it. I don't enforce that the timer
+    // is dropped before the metrics, because tokio::spawn
+    // requires that the closure is owned for 'static. So
+    // extremely rigorous correctness takes a backseat to
+    // usability here.
+    Timer {
+        nanos: Arc<AtomicUsize>,
+    }
 }
 
 impl From<&Observation> for f64 {

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -1,4 +1,8 @@
-use std::{fmt::Display, sync::{Arc, atomic::AtomicUsize}, time::Duration};
+use std::{
+    fmt::Display,
+    sync::{atomic::AtomicUsize, Arc},
+    time::Duration,
+};
 
 /// The value part of a dimension's key/value pair.
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
@@ -110,9 +114,7 @@ pub enum Distribution {
     // requires that the closure is owned for 'static. So
     // extremely rigorous correctness takes a backseat to
     // usability here.
-    Timer {
-        nanos: Arc<AtomicUsize>,
-    }
+    Timer { nanos: Arc<AtomicUsize> },
 }
 
 impl From<&Observation> for f64 {


### PR DESCRIPTION
Breaking change, Metrics no longer supports internal mutability. The runtime cost to users that don't need it is not worth the convenience to those who do - and I'm not aware of anyone who actually needs it at present.

A new caching allocator, like the pooled_metrics_allocator, the arc_allocator relies on Arc instead of the borrow checker. While structural borrow checking is definitely better than Arc, in practice Metrics pipelines are complex enough that the lifecycles of Metrics references downstream are massively easier to work with when they are owned. In particular, the StreamSink is hard to use while satisfying lifetime requirements. It is expected that in practice the arc_allocator will not be much worse than the pooled_metrics_allocator.

arc_allocator uses an optimistic 8-slot concurrency model. It tries to avoid colliding locks for checking out and returning objects. This means it might allocate extra Metrics that a strict policy wouldn't, but synchronization is considered more likely to be problematic than an extra Metrics object here and there.

Make sure you set your cache size to something appropriate for your use case. The minimum is 16*8 = 128. Powers of 2 will get you accurate buffer sizes; anything else will not.