### PR TITLE
switch streamsink to std::sync::mpsc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 
 [workspace]
+resolver = "2"
+
 members = [
     "proto_generator",
     "lib",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/kvc0/goodmetrics_rs"
 keywords = ["metrics", "goodmetrics", "service", "performance"]
 categories = ["web-programming", "development-tools::profiling"]
 
+[features]
+ahash-hasher = ["ahash"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
@@ -30,6 +33,8 @@ name = "goodmetrics"
 harness = false
 
 [dependencies]
+ahash = { version = "0.8", optional = true }
+
 log =  { version = "0.4" }
 
 futures = { version = "0.3" }

--- a/lib/src/allocator/always_new_metrics_allocator.rs
+++ b/lib/src/allocator/always_new_metrics_allocator.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::{hash_map::RandomState, HashMap},
-    hash::BuildHasher,
-    marker::PhantomData,
-    time::Instant,
-};
+use std::{collections::HashMap, hash::BuildHasher, time::Instant};
 
 use crate::{
     metrics::{Metrics, MetricsBehavior},
@@ -15,29 +10,16 @@ use super::MetricsAllocator;
 /// Allocator which always creates a new instance.
 /// Probably you will want PooledMetricsAllocator if you are doing
 /// something with very tight timing constraints.
-#[derive(Clone)]
-pub struct AlwaysNewMetricsAllocator<TBuildHasher = RandomState> {
-    _phantom: PhantomData<TBuildHasher>,
-}
+#[derive(Clone, Default)]
+pub struct AlwaysNewMetricsAllocator;
 
-impl<T: BuildHasher> AlwaysNewMetricsAllocator<T> {
+impl AlwaysNewMetricsAllocator {
     pub fn new() -> Self {
-        Self {
-            _phantom: Default::default(),
-        }
+        Self
     }
 }
 
-impl Default for AlwaysNewMetricsAllocator<RandomState> {
-    fn default() -> Self {
-        Self {
-            _phantom: Default::default(),
-        }
-    }
-}
-
-impl<'a, TBuildHasher> MetricsAllocator<'a, Metrics<TBuildHasher>>
-    for AlwaysNewMetricsAllocator<TBuildHasher>
+impl<'a, TBuildHasher> MetricsAllocator<'a, Metrics<TBuildHasher>> for AlwaysNewMetricsAllocator
 where
     TBuildHasher: BuildHasher + Default + 'a,
 {

--- a/lib/src/allocator/arc_allocator.rs
+++ b/lib/src/allocator/arc_allocator.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::{
     cmp::max,
-    collections::{hash_map::RandomState, HashMap},
+    collections::HashMap,
     hash::BuildHasher,
     mem::take,
     ops::{Deref, DerefMut},
@@ -12,13 +12,13 @@ use std::{
     time::Instant,
 };
 
-use super::MetricsAllocator;
+use super::{Hasher, MetricsAllocator};
 
 /// A metrics allocator that prioritizes reusing Metrics objects, but with a gentler
 /// Borrow Checker constraint. References are owned, so it's easier to pass them
 /// around.
 #[derive(Clone)]
-pub struct ArcAllocator<TBuildHasher: Send = RandomState> {
+pub struct ArcAllocator<TBuildHasher: Send = Hasher> {
     state: Arc<AllocatorState<TBuildHasher>>,
 }
 
@@ -109,7 +109,7 @@ where
     }
 }
 
-pub struct CachedMetrics<TBuildHasher = RandomState>
+pub struct CachedMetrics<TBuildHasher = Hasher>
 where
     TBuildHasher: BuildHasher + Default + Send + 'static,
 {

--- a/lib/src/allocator/mod.rs
+++ b/lib/src/allocator/mod.rs
@@ -1,4 +1,10 @@
+#[cfg(not(feature = "ahash-hasher"))]
 use std::collections::hash_map::RandomState;
+
+#[cfg(feature = "ahash-hasher")]
+use ahash::RandomState;
+
+pub type Hasher = RandomState;
 
 use crate::{metrics::Metrics, types::Name};
 

--- a/lib/src/allocator/pooled_metrics_allocator.rs
+++ b/lib/src/allocator/pooled_metrics_allocator.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{hash_map::RandomState, HashMap},
-    hash::BuildHasher,
-    time::Instant,
-};
+use std::{collections::HashMap, hash::BuildHasher, time::Instant};
 
 use object_pool::{Pool, Reusable};
 
@@ -11,9 +7,9 @@ use crate::{
     types::Name,
 };
 
-use super::MetricsAllocator;
+use super::{Hasher, MetricsAllocator};
 
-pub struct PooledMetricsAllocator<TBuildHasher = RandomState> {
+pub struct PooledMetricsAllocator<TBuildHasher = Hasher> {
     pool: Pool<Metrics<TBuildHasher>>,
     size: usize,
 }
@@ -44,7 +40,7 @@ impl<T: BuildHasher + Default> PooledMetricsAllocator<T> {
     }
 }
 
-impl Default for PooledMetricsAllocator<RandomState> {
+impl<H: BuildHasher + Default> Default for PooledMetricsAllocator<H> {
     fn default() -> Self {
         Self::new(128)
     }

--- a/lib/src/metrics.rs
+++ b/lib/src/metrics.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{self, HashMap},
+    collections::HashMap,
     fmt::Display,
     hash::BuildHasher,
     sync::{atomic::AtomicUsize, Arc},
@@ -8,7 +8,10 @@ use std::{
 
 use futures::channel::oneshot;
 
-use crate::types::{Dimension, Distribution, Measurement, Name, Observation};
+use crate::{
+    allocator::Hasher,
+    types::{Dimension, Distribution, Measurement, Name, Observation},
+};
 
 #[derive(Clone, Copy, Debug)]
 pub enum MetricsBehavior {
@@ -39,7 +42,7 @@ pub enum MetricsBehavior {
 /// Generally prefer to record dimensions as early as possible, in case you
 /// early-out somewhere; in this way you'll have more information in those cases.
 #[derive(Debug)]
-pub struct Metrics<TBuildHasher = collections::hash_map::RandomState> {
+pub struct Metrics<TBuildHasher = Hasher> {
     pub(crate) metrics_name: Name,
     pub(crate) start_time: Instant,
     dimensions: HashMap<Name, Dimension, TBuildHasher>,
@@ -96,14 +99,14 @@ impl OverrideDimension {
     }
 }
 
-impl AsRef<Metrics> for Metrics {
-    fn as_ref(&self) -> &Metrics {
+impl<H> AsRef<Metrics<H>> for Metrics<H> {
+    fn as_ref(&self) -> &Metrics<H> {
         self
     }
 }
 
-impl AsMut<Metrics> for Metrics {
-    fn as_mut(&mut self) -> &mut Metrics {
+impl<H> AsMut<Metrics<H>> for Metrics<H> {
+    fn as_mut(&mut self) -> &mut Metrics<H> {
         self
     }
 }

--- a/lib/src/metrics_factory.rs
+++ b/lib/src/metrics_factory.rs
@@ -362,7 +362,7 @@ mod test {
         > = MetricsFactory::new_with_allocator(
             SerializingSink::new(LoggingSink::default()),
             &[MetricsBehavior::Default],
-            AlwaysNewMetricsAllocator::default(),
+            AlwaysNewMetricsAllocator,
         );
         let mut metrics = metrics_factory.record_scope("test");
         // Dimension the scoped metrics
@@ -379,7 +379,7 @@ mod test {
             MetricsFactory::new_with_allocator(
                 stream_sink,
                 &[MetricsBehavior::Default],
-                AlwaysNewMetricsAllocator::default(),
+                AlwaysNewMetricsAllocator,
             );
         #[allow(clippy::redundant_clone)]
         let cloned = metrics_factory.clone();

--- a/lib/src/pipeline/stream_sink.rs
+++ b/lib/src/pipeline/stream_sink.rs
@@ -1,10 +1,10 @@
-use tokio::sync::mpsc;
+use std::sync::mpsc;
 
 use super::Sink;
 
 #[derive(Debug)]
 pub struct StreamSink<TMetricsRef> {
-    queue: mpsc::Sender<TMetricsRef>,
+    queue: mpsc::SyncSender<TMetricsRef>,
 }
 
 impl<TMetricsRef> Clone for StreamSink<TMetricsRef> {
@@ -17,7 +17,7 @@ impl<TMetricsRef> Clone for StreamSink<TMetricsRef> {
 
 impl<TMetricsRef> StreamSink<TMetricsRef> {
     pub fn new() -> (Self, mpsc::Receiver<TMetricsRef>) {
-        let (sender, receiver) = mpsc::channel(1024);
+        let (sender, receiver) = mpsc::sync_channel(1024);
 
         (Self { queue: sender }, receiver)
     }


### PR DESCRIPTION
The tokio::sync::mpsc costs a lot of time when doing a cross-runtime wake. A normal way to use metrics is to split the reporting thread(s) from the service/recording threads. It's natural to put each in their respective runtimes. That's not a good configuration for a tokio mpsc, and it measures to be way too expensive in at least 1 service.

By contrast, the std channel does a good job across threads. The main drawback here is that there's no await, so the Aggregator has to poll. Probably it will be fine for expected deployment scenarios, but of course, pr's welcome.