### PR TITLE
Add exponential histogram

### DIFF
--- a/lib/benches/benchmarks/aggregation.rs
+++ b/lib/benches/benchmarks/aggregation.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use criterion::Criterion;
+use criterion::{measurement::WallTime, BenchmarkGroup, Criterion};
 use goodmetrics::{
     allocator::always_new_metrics_allocator::AlwaysNewMetricsAllocator,
     downstream::opentelemetry_downstream::create_preaggregated_opentelemetry_batch,
@@ -20,9 +20,14 @@ pub fn aggregation(criterion: &mut Criterion) {
 
     let mut group = criterion.benchmark_group("aggregation");
     group.throughput(criterion::Throughput::Elements(1));
+    bench_distribution_mode(&mut group, DistributionMode::Histogram);
+    bench_distribution_mode(&mut group, DistributionMode::ExponentialHistogram { max_buckets: 160 });
+    bench_distribution_mode(&mut group, DistributionMode::TDigest);
+}
 
+fn bench_distribution_mode(group: &mut BenchmarkGroup<'_, WallTime>, distribution_mode: DistributionMode) {
     let (sink, receiver) = StreamSink::new();
-    let aggregator = Aggregator::new(receiver, DistributionMode::Histogram);
+    let aggregator = Aggregator::new(receiver, distribution_mode);
     let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, StreamSink<_>> =
         MetricsFactory::new(sink);
     let (aggregated_batch_sender, _r) = mpsc::channel(128);
@@ -37,8 +42,8 @@ pub fn aggregation(criterion: &mut Criterion) {
         create_preaggregated_opentelemetry_batch,
     ));
 
-    for threads in [1, 2, 4, 8, 16] {
-        group.bench_function(format!("concurrency-{threads:02}"), |bencher| {
+    for threads in [1, 4, 16] {
+        group.bench_function(format!("{distribution_mode}-concurrency-{threads:02}"), |bencher| {
             bencher.iter_custom(|iterations| {
                 let thread_count = max(1, min(threads, iterations));
                 let iterations_per_thread = iterations / thread_count;

--- a/lib/benches/benchmarks/aggregation.rs
+++ b/lib/benches/benchmarks/aggregation.rs
@@ -21,11 +21,17 @@ pub fn aggregation(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("aggregation");
     group.throughput(criterion::Throughput::Elements(1));
     bench_distribution_mode(&mut group, DistributionMode::Histogram);
-    bench_distribution_mode(&mut group, DistributionMode::ExponentialHistogram { max_buckets: 160 });
+    bench_distribution_mode(
+        &mut group,
+        DistributionMode::ExponentialHistogram { max_buckets: 160 },
+    );
     bench_distribution_mode(&mut group, DistributionMode::TDigest);
 }
 
-fn bench_distribution_mode(group: &mut BenchmarkGroup<'_, WallTime>, distribution_mode: DistributionMode) {
+fn bench_distribution_mode(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    distribution_mode: DistributionMode,
+) {
     let (sink, receiver) = StreamSink::new();
     let aggregator = Aggregator::new(receiver, distribution_mode);
     let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, StreamSink<_>> =
@@ -43,28 +49,31 @@ fn bench_distribution_mode(group: &mut BenchmarkGroup<'_, WallTime>, distributio
     ));
 
     for threads in [1, 4, 16] {
-        group.bench_function(format!("{distribution_mode}-concurrency-{threads:02}"), |bencher| {
-            bencher.iter_custom(|iterations| {
-                let thread_count = max(1, min(threads, iterations));
-                let iterations_per_thread = iterations / thread_count;
+        group.bench_function(
+            format!("{distribution_mode}-concurrency-{threads:02}"),
+            |bencher| {
+                bencher.iter_custom(|iterations| {
+                    let thread_count = max(1, min(threads, iterations));
+                    let iterations_per_thread = iterations / thread_count;
 
-                let start = Instant::now();
-                std::thread::scope(|scope| {
-                    for _ in 0..thread_count {
-                        scope.spawn(|| {
-                            for i in 0..iterations_per_thread {
-                                let mut metrics = metrics_factory.record_scope("demo");
-                                let _scope = metrics.time("timed_delay");
-                                metrics.measurement("ran", 1);
-                                metrics.dimension("mod", i % 8);
-                            }
-                        });
-                    }
+                    let start = Instant::now();
+                    std::thread::scope(|scope| {
+                        for _ in 0..thread_count {
+                            scope.spawn(|| {
+                                for i in 0..iterations_per_thread {
+                                    let mut metrics = metrics_factory.record_scope("demo");
+                                    let _scope = metrics.time("timed_delay");
+                                    metrics.measurement("ran", 1);
+                                    metrics.dimension("mod", i % 8);
+                                }
+                            });
+                        }
+                    });
+
+                    start.elapsed()
                 });
-
-                start.elapsed()
-            });
-        });
+            },
+        );
     }
 }
 

--- a/lib/src/downstream/goodmetrics_downstream.rs
+++ b/lib/src/downstream/goodmetrics_downstream.rs
@@ -8,7 +8,8 @@ use tokio::sync::mpsc;
 use crate::{
     pipeline::{
         aggregation::{
-            exponential_histogram::ExponentialHistogram, online_tdigest::OnlineTdigest, statistic_set::StatisticSet, tdigest::Centroid, Aggregation
+            exponential_histogram::ExponentialHistogram, online_tdigest::OnlineTdigest,
+            statistic_set::StatisticSet, tdigest::Centroid, Aggregation,
         },
         aggregator::{AggregatedMetricsMap, DimensionedMeasurementsMap},
         AbsorbDistribution,
@@ -154,7 +155,7 @@ impl From<Aggregation> for proto::goodmetrics::Measurement {
                 Aggregation::ExponentialHistogram(histogram) => {
                     proto::goodmetrics::measurement::Value::Histogram(
                         proto::goodmetrics::Histogram {
-                            buckets: make_histogram(histogram)
+                            buckets: make_histogram(histogram),
                         },
                     )
                 }
@@ -165,9 +166,8 @@ impl From<Aggregation> for proto::goodmetrics::Measurement {
 
 fn make_histogram(eh: ExponentialHistogram) -> HashMap<i64, u64> {
     HashMap::from_iter(
-        eh.value_counts().map(
-            |(value, count)| (value.round() as i64, count as u64)
-        )
+        eh.value_counts()
+            .map(|(value, count)| (value.round() as i64, count as u64)),
     )
 }
 

--- a/lib/src/downstream/goodmetrics_downstream.rs
+++ b/lib/src/downstream/goodmetrics_downstream.rs
@@ -8,8 +8,7 @@ use tokio::sync::mpsc;
 use crate::{
     pipeline::{
         aggregation::{
-            online_tdigest::OnlineTdigest, statistic_set::StatisticSet, tdigest::Centroid,
-            Aggregation,
+            exponential_histogram::ExponentialHistogram, online_tdigest::OnlineTdigest, statistic_set::StatisticSet, tdigest::Centroid, Aggregation
         },
         aggregator::{AggregatedMetricsMap, DimensionedMeasurementsMap},
         AbsorbDistribution,
@@ -152,9 +151,24 @@ impl From<Aggregation> for proto::goodmetrics::Measurement {
                 Aggregation::TDigest(t_digest) => {
                     proto::goodmetrics::measurement::Value::Tdigest(t_digest.into())
                 }
+                Aggregation::ExponentialHistogram(histogram) => {
+                    proto::goodmetrics::measurement::Value::Histogram(
+                        proto::goodmetrics::Histogram {
+                            buckets: make_histogram(histogram)
+                        },
+                    )
+                }
             }),
         }
     }
+}
+
+fn make_histogram(eh: ExponentialHistogram) -> HashMap<i64, u64> {
+    HashMap::from_iter(
+        eh.value_counts().map(
+            |(value, count)| (value.round() as i64, count as u64)
+        )
+    )
 }
 
 impl From<Measurement> for proto::goodmetrics::Measurement {

--- a/lib/src/pipeline/aggregation/exponential_histogram.rs
+++ b/lib/src/pipeline/aggregation/exponential_histogram.rs
@@ -1,7 +1,10 @@
-use std::{cmp::min, f64::consts::{E, LN_2, LOG2_E}, sync::atomic::Ordering};
+use std::{
+    cmp::min,
+    f64::consts::{E, LN_2, LOG2_E},
+    sync::atomic::Ordering,
+};
 
 use crate::{pipeline::AbsorbDistribution, types::Distribution};
-
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExponentialHistogram {
@@ -39,7 +42,8 @@ impl ExponentialHistogram {
             buckets.reserve_exact(self.max_bucket_index as usize + 1);
             // SAFETY: immediately initialize to 0 without doing repeated capacity checks, only index checks
             unsafe { buckets.set_len(self.max_bucket_index as usize + 1) };
-            for i in &mut *buckets { // reborrow
+            for i in &mut *buckets {
+                // reborrow
                 *i = 0;
             }
         }
@@ -59,7 +63,8 @@ impl ExponentialHistogram {
 
     /// This is an approximation, just using the positive buckets for the sum.
     pub fn sum(&self) -> f64 {
-        self.positive_buckets.iter()
+        self.positive_buckets
+            .iter()
             .enumerate()
             .map(|(index, count)| self.lower_boundary(index) * *count as f64)
             .sum()
@@ -67,7 +72,8 @@ impl ExponentialHistogram {
 
     /// This is an approximation, just using the positive buckets for the min.
     pub fn min(&self) -> f64 {
-        self.positive_buckets.iter()
+        self.positive_buckets
+            .iter()
             .enumerate()
             .filter(|(_, count)| 0 < **count)
             .map(|(index, _count)| self.lower_boundary(index))
@@ -77,7 +83,8 @@ impl ExponentialHistogram {
 
     /// This is an approximation, just using the positive buckets for the max.
     pub fn max(&self) -> f64 {
-        self.positive_buckets.iter()
+        self.positive_buckets
+            .iter()
             .enumerate()
             .rev()
             .filter(|(_, count)| 0 < **count)
@@ -103,9 +110,16 @@ impl ExponentialHistogram {
     }
 
     pub fn value_counts(&self) -> impl Iterator<Item = (f64, usize)> + '_ {
-        self.negative_buckets.iter().enumerate().map(|(index, count)| (self.lower_boundary(index), *count)).chain(
-            self.positive_buckets.iter().enumerate().map(|(index, count)| (self.lower_boundary(index), *count))
-        )
+        self.negative_buckets
+            .iter()
+            .enumerate()
+            .map(|(index, count)| (self.lower_boundary(index), *count))
+            .chain(
+                self.positive_buckets
+                    .iter()
+                    .enumerate()
+                    .map(|(index, count)| (self.lower_boundary(index), *count)),
+            )
     }
 
     /// treats negative numbers as positive - you gotta accumulate into a negative array
@@ -140,9 +154,7 @@ impl AbsorbDistribution for ExponentialHistogram {
                     self.accumulate(i as f64)
                 }
             }
-            Distribution::Timer { nanos } => {
-                self.accumulate(nanos.load(Ordering::Relaxed) as f64)
-            }
+            Distribution::Timer { nanos } => self.accumulate(nanos.load(Ordering::Relaxed) as f64),
         }
     }
 }
@@ -195,7 +207,11 @@ mod test {
         assert_value_index_lowerboundary(&e, 8, 5.657);
         assert_value_index_lowerboundary(&e, 8.1, 8);
 
-        assert_eq_epsilon(854839645001008300000000_f64, e.lower_boundary(160), "scale 1 goes very high with 160 buckets");
+        assert_eq_epsilon(
+            854839645001008300000000_f64,
+            e.lower_boundary(160),
+            "scale 1 goes very high with 160 buckets",
+        );
     }
 
     #[test]
@@ -212,16 +228,48 @@ mod test {
         assert_value_index_lowerboundary(&e, 8, 6.727);
         assert_value_index_lowerboundary(&e, 8.1, 8);
 
-        assert_eq_epsilon(924575386326.615_f64, e.lower_boundary(159), "scale 2 goes to 924 billion with 160 buckets");
-        assert_eq_epsilon(777472127993.868_f64, e.lower_boundary(158), "scale 2 loses a lot of precision at the end of the scale");
-        
-        assert_eq_epsilon(28215801.585_f64, e.lower_boundary(99), "scale 2 has a reasonable precision in the middle");
-        assert_eq_epsilon(33554432.000_f64, e.lower_boundary(100), "scale 2 has a reasonable precision in the middle");
-        assert_eq_epsilon(39903169.274_f64, e.lower_boundary(101), "scale 2 has a reasonable precision in the middle");
+        assert_eq_epsilon(
+            924575386326.615_f64,
+            e.lower_boundary(159),
+            "scale 2 goes to 924 billion with 160 buckets",
+        );
+        assert_eq_epsilon(
+            777472127993.868_f64,
+            e.lower_boundary(158),
+            "scale 2 loses a lot of precision at the end of the scale",
+        );
 
-        assert_eq_epsilon(881743.800_f64, e.lower_boundary(79), "scale 2 has a reasonable precision near 1 million");
-        assert_eq_epsilon(1048576.000_f64, e.lower_boundary(80), "scale 2 has a reasonable precision near 1 million");
-        assert_eq_epsilon(1246974.040_f64, e.lower_boundary(81), "scale 2 has a reasonable precision near 1 million");
+        assert_eq_epsilon(
+            28215801.585_f64,
+            e.lower_boundary(99),
+            "scale 2 has a reasonable precision in the middle",
+        );
+        assert_eq_epsilon(
+            33554432.000_f64,
+            e.lower_boundary(100),
+            "scale 2 has a reasonable precision in the middle",
+        );
+        assert_eq_epsilon(
+            39903169.274_f64,
+            e.lower_boundary(101),
+            "scale 2 has a reasonable precision in the middle",
+        );
+
+        assert_eq_epsilon(
+            881743.800_f64,
+            e.lower_boundary(79),
+            "scale 2 has a reasonable precision near 1 million",
+        );
+        assert_eq_epsilon(
+            1048576.000_f64,
+            e.lower_boundary(80),
+            "scale 2 has a reasonable precision near 1 million",
+        );
+        assert_eq_epsilon(
+            1246974.040_f64,
+            e.lower_boundary(81),
+            "scale 2 has a reasonable precision near 1 million",
+        );
     }
 
     #[test]
@@ -238,7 +286,11 @@ mod test {
         assert_value_index_lowerboundary(&e, 8, 7.337);
         assert_value_index_lowerboundary(&e, 8.1, 8);
 
-        assert_eq_epsilon(961548.432_f64, e.lower_boundary(160), "scale 3 goes to just 0.96 million with 160 buckets");
+        assert_eq_epsilon(
+            961548.432_f64,
+            e.lower_boundary(160),
+            "scale 3 goes to just 0.96 million with 160 buckets",
+        );
     }
 
     #[test]
@@ -257,20 +309,35 @@ mod test {
         assert_value_index_lowerboundary(&e, 8, 7.661);
         assert_value_index_lowerboundary(&e, 8.1, 8);
 
-        assert_eq_epsilon(980.586_f64, e.lower_boundary(160), "scale 4 goes to just 980 with 160 buckets");
+        assert_eq_epsilon(
+            980.586_f64,
+            e.lower_boundary(160),
+            "scale 4 goes to just 980 with 160 buckets",
+        );
     }
 
     #[track_caller]
-    fn assert_value_index_lowerboundary(e: &ExponentialHistogram, value: impl Into<f64>, expected_lower_boundary: impl Into<f64>) {
+    fn assert_value_index_lowerboundary(
+        e: &ExponentialHistogram,
+        value: impl Into<f64>,
+        expected_lower_boundary: impl Into<f64>,
+    ) {
         let observed_index = e.map_to_index(value.into());
         let observed_boundary = e.lower_boundary(observed_index);
-        assert_eq_epsilon(expected_lower_boundary.into(), observed_boundary, "boundary matches");
+        assert_eq_epsilon(
+            expected_lower_boundary.into(),
+            observed_boundary,
+            "boundary matches",
+        );
     }
 
     #[track_caller]
     fn assert_eq_epsilon(j: f64, k: f64, message: &str) {
         const EPSILON: f64 = 1.0 / 128.0;
         let difference = (j - k).abs();
-        assert!(difference < EPSILON, "{message}: {j} != {k} with epsilon {EPSILON}.");
+        assert!(
+            difference < EPSILON,
+            "{message}: {j} != {k} with epsilon {EPSILON}."
+        );
     }
 }

--- a/lib/src/pipeline/aggregation/exponential_histogram.rs
+++ b/lib/src/pipeline/aggregation/exponential_histogram.rs
@@ -1,0 +1,192 @@
+use std::{cmp::min, f64::consts::{E, LN_2, LOG2_E}};
+
+
+pub struct ExponentialHistogram {
+    scale: u32,
+    max_bucket_index: u32,
+    positive_buckets: Vec<usize>,
+    negative_buckets: Vec<usize>,
+}
+
+impl ExponentialHistogram {
+    pub fn new(scale: u32) -> Self {
+        Self::new_with_max_buckets(scale, 160)
+    }
+
+    pub fn new_with_max_buckets(scale: u32, max_buckets: u32) -> Self {
+        Self {
+            scale,
+            max_bucket_index: max_buckets - 1,
+            positive_buckets: Default::default(),
+            negative_buckets: Default::default(),
+        }
+    }
+
+    pub fn accumulate<T: Into<f64>>(&mut self, value: T) {
+        let value = value.into();
+        let index = self.map_to_index(value);
+        let buckets = if value.is_sign_positive() {
+            &mut self.positive_buckets
+        } else {
+            &mut self.negative_buckets
+        };
+        if buckets.is_empty() {
+            // I could reserve these ahead of time, but it seems likely that many uses will have exclusively
+            // positive or exclusively negative numbers - so this saves memory in those cases.
+            buckets.reserve_exact(self.max_bucket_index as usize + 1);
+            // SAFETY: immediately initialize to 0 without doing repeated capacity checks, only index checks
+            unsafe { buckets.set_len(self.max_bucket_index as usize + 1) };
+            for i in &mut *buckets { // reborrow
+                *i = 0;
+            }
+        }
+        buckets[index] += 1;
+    }
+
+    /// treats negative numbers as positive - you gotta accumulate into a negative array
+    fn map_to_index(&self, raw_value: f64) -> usize {
+        let value = raw_value.abs();
+        let scale_factor = LOG2_E * 2_f64.powi(self.scale as i32);
+        let index = (value.log(E) * scale_factor).floor() as usize;
+        min(self.max_bucket_index as usize, index)
+    }
+
+    /// obviously only supports positive indices. If you want a negative boundary, flip the sign on the return value.
+    /// per the wonkadoo instructions found at: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram
+    ///   > The positive and negative ranges of the histogram are expressed separately. Negative values are mapped by
+    ///   > their absolute value into the negative range using the same scale as the positive range. Note that in the
+    ///   > negative range, therefore, histogram buckets use lower-inclusive boundaries.
+    fn lower_boundary(&self, index: usize) -> f64 {
+        let index = min(self.max_bucket_index as usize, index);
+        let inverse_scale_factor = LN_2 * 2_f64.powi(-(self.scale as i32));
+        (index as f64 * inverse_scale_factor).exp()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ExponentialHistogram;
+
+    #[test]
+    fn indices_scale_zero_positive_numbers() {
+        let e = ExponentialHistogram::new(0);
+
+        assert_eq!(0, e.map_to_index(0_f64));
+        assert_value_index_lowerboundary(&e, 0, 1);
+        assert_value_index_lowerboundary(&e, 1, 1);
+        assert_value_index_lowerboundary(&e, 2, 2);
+        assert_value_index_lowerboundary(&e, 3, 2);
+        assert_value_index_lowerboundary(&e, 4, 4);
+        assert_value_index_lowerboundary(&e, 7, 4);
+        assert_value_index_lowerboundary(&e, 8, 4);
+        assert_value_index_lowerboundary(&e, 8.1, 8);
+    }
+
+    #[test]
+    fn indices_scale_zero_negative_numbers() {
+        let e = ExponentialHistogram::new(0);
+
+        assert_eq!(0, e.map_to_index(0_f64));
+        assert_value_index_lowerboundary(&e, -0, 1);
+        assert_value_index_lowerboundary(&e, -1, 1);
+        assert_value_index_lowerboundary(&e, -2, 2);
+        assert_value_index_lowerboundary(&e, -3, 2);
+        assert_value_index_lowerboundary(&e, -4, 4);
+        assert_value_index_lowerboundary(&e, -7, 4);
+        assert_value_index_lowerboundary(&e, -8, 4);
+        assert_value_index_lowerboundary(&e, -8.1, 8);
+    }
+
+    #[test]
+    fn indices_scale_one_positive_numbers() {
+        let e = ExponentialHistogram::new(1);
+
+        assert_eq!(0, e.map_to_index(0_f64));
+        assert_value_index_lowerboundary(&e, 0, 1);
+        assert_value_index_lowerboundary(&e, 1, 1);
+        assert_value_index_lowerboundary(&e, 2, 2);
+        assert_value_index_lowerboundary(&e, 3, 2.828);
+        assert_value_index_lowerboundary(&e, 4, 4);
+        assert_value_index_lowerboundary(&e, 7, 5.657);
+        assert_value_index_lowerboundary(&e, 8, 5.657);
+        assert_value_index_lowerboundary(&e, 8.1, 8);
+
+        assert_eq_epsilon(854839645001008300000000_f64, e.lower_boundary(160), "scale 1 goes very high with 160 buckets");
+    }
+
+    #[test]
+    fn indices_scale_two_positive_numbers() {
+        let e = ExponentialHistogram::new(2);
+
+        assert_eq!(0, e.map_to_index(0_f64));
+        assert_value_index_lowerboundary(&e, 0, 1);
+        assert_value_index_lowerboundary(&e, 1, 1);
+        assert_value_index_lowerboundary(&e, 2, 2);
+        assert_value_index_lowerboundary(&e, 3, 2.828);
+        assert_value_index_lowerboundary(&e, 4, 4);
+        assert_value_index_lowerboundary(&e, 7, 6.727);
+        assert_value_index_lowerboundary(&e, 8, 6.727);
+        assert_value_index_lowerboundary(&e, 8.1, 8);
+
+        assert_eq_epsilon(924575386326.615_f64, e.lower_boundary(159), "scale 2 goes to 924 billion with 160 buckets");
+        assert_eq_epsilon(777472127993.868_f64, e.lower_boundary(158), "scale 2 loses a lot of precision at the end of the scale");
+        
+        assert_eq_epsilon(28215801.585_f64, e.lower_boundary(99), "scale 2 has a reasonable precision in the middle");
+        assert_eq_epsilon(33554432.000_f64, e.lower_boundary(100), "scale 2 has a reasonable precision in the middle");
+        assert_eq_epsilon(39903169.274_f64, e.lower_boundary(101), "scale 2 has a reasonable precision in the middle");
+
+        assert_eq_epsilon(881743.800_f64, e.lower_boundary(79), "scale 2 has a reasonable precision near 1 million");
+        assert_eq_epsilon(1048576.000_f64, e.lower_boundary(80), "scale 2 has a reasonable precision near 1 million");
+        assert_eq_epsilon(1246974.040_f64, e.lower_boundary(81), "scale 2 has a reasonable precision near 1 million");
+    }
+
+    #[test]
+    fn indices_scale_three_positive_numbers() {
+        let e = ExponentialHistogram::new(3);
+
+        assert_eq!(0, e.map_to_index(0_f64));
+        assert_value_index_lowerboundary(&e, 0, 1);
+        assert_value_index_lowerboundary(&e, 1, 1);
+        assert_value_index_lowerboundary(&e, 2, 2);
+        assert_value_index_lowerboundary(&e, 3, 2.828);
+        assert_value_index_lowerboundary(&e, 4, 4);
+        assert_value_index_lowerboundary(&e, 7, 6.727);
+        assert_value_index_lowerboundary(&e, 8, 7.337);
+        assert_value_index_lowerboundary(&e, 8.1, 8);
+
+        assert_eq_epsilon(961548.432_f64, e.lower_boundary(160), "scale 3 goes to just 0.96 million with 160 buckets");
+    }
+
+    #[test]
+    fn indices_scale_four_positive_numbers() {
+        let e = ExponentialHistogram::new(4);
+
+        assert_eq!(0, e.map_to_index(0_f64));
+        assert_value_index_lowerboundary(&e, 0, 1);
+        assert_value_index_lowerboundary(&e, 1, 1);
+        assert_value_index_lowerboundary(&e, 2, 2);
+        assert_value_index_lowerboundary(&e, 3, 2.954);
+        assert_value_index_lowerboundary(&e, 4, 4);
+        assert_value_index_lowerboundary(&e, 5, 4.967);
+        assert_value_index_lowerboundary(&e, 6, 5.907);
+        assert_value_index_lowerboundary(&e, 7, 6.727);
+        assert_value_index_lowerboundary(&e, 8, 7.661);
+        assert_value_index_lowerboundary(&e, 8.1, 8);
+
+        assert_eq_epsilon(980.586_f64, e.lower_boundary(160), "scale 4 goes to just 980 with 160 buckets");
+    }
+
+    #[track_caller]
+    fn assert_value_index_lowerboundary(e: &ExponentialHistogram, value: impl Into<f64>, expected_lower_boundary: impl Into<f64>) {
+        let observed_index = e.map_to_index(value.into());
+        let observed_boundary = e.lower_boundary(observed_index);
+        assert_eq_epsilon(expected_lower_boundary.into(), observed_boundary, "boundary matches");
+    }
+
+    #[track_caller]
+    fn assert_eq_epsilon(j: f64, k: f64, message: &str) {
+        const EPSILON: f64 = 1.0 / 128.0;
+        let difference = (j - k).abs();
+        assert!(difference < EPSILON, "{message}: {j} != {k} with epsilon {EPSILON}.");
+    }
+}

--- a/lib/src/pipeline/aggregation/mod.rs
+++ b/lib/src/pipeline/aggregation/mod.rs
@@ -1,4 +1,7 @@
-use self::{exponential_histogram::ExponentialHistogram, histogram::Histogram, online_tdigest::OnlineTdigest, statistic_set::StatisticSet};
+use self::{
+    exponential_histogram::ExponentialHistogram, histogram::Histogram,
+    online_tdigest::OnlineTdigest, statistic_set::StatisticSet,
+};
 
 pub mod bucket;
 pub mod exponential_histogram;

--- a/lib/src/pipeline/aggregation/mod.rs
+++ b/lib/src/pipeline/aggregation/mod.rs
@@ -1,4 +1,4 @@
-use self::{histogram::Histogram, online_tdigest::OnlineTdigest, statistic_set::StatisticSet};
+use self::{exponential_histogram::ExponentialHistogram, histogram::Histogram, online_tdigest::OnlineTdigest, statistic_set::StatisticSet};
 
 pub mod bucket;
 pub mod exponential_histogram;
@@ -14,6 +14,7 @@ pub mod tdigest;
 /// For collecting and periodically reporting
 #[derive(Debug, Clone)]
 pub enum Aggregation {
+    ExponentialHistogram(ExponentialHistogram),
     Histogram(Histogram),
     StatisticSet(StatisticSet),
     TDigest(OnlineTdigest),
@@ -22,6 +23,7 @@ pub enum Aggregation {
 impl PartialEq for Aggregation {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (Self::ExponentialHistogram(l), Self::ExponentialHistogram(r)) => l == r,
             (Self::Histogram(l), Self::Histogram(r)) => l == r,
             (Self::StatisticSet(l), Self::StatisticSet(r)) => l == r,
             _ => false,

--- a/lib/src/pipeline/aggregation/mod.rs
+++ b/lib/src/pipeline/aggregation/mod.rs
@@ -1,6 +1,7 @@
 use self::{histogram::Histogram, online_tdigest::OnlineTdigest, statistic_set::StatisticSet};
 
 pub mod bucket;
+pub mod exponential_histogram;
 pub mod histogram;
 pub mod online_tdigest;
 pub mod statistic_set;

--- a/lib/src/pipeline/aggregation/tdigest.rs
+++ b/lib/src/pipeline/aggregation/tdigest.rs
@@ -304,7 +304,7 @@ impl TDigest {
         result
     }
 
-    fn external_merge(centroids: &mut Vec<Centroid>, first: usize, middle: usize, last: usize) {
+    fn external_merge(centroids: &mut [Centroid], first: usize, middle: usize, last: usize) {
         let mut result: Vec<Centroid> = Vec::with_capacity(centroids.len());
 
         let mut i = first;

--- a/lib/src/pipeline/aggregator.rs
+++ b/lib/src/pipeline/aggregator.rs
@@ -1,8 +1,5 @@
 use std::{
-    cmp::min,
-    collections::{BTreeMap, HashMap},
-    mem::replace,
-    time::{Duration, Instant, SystemTime},
+    cmp::min, collections::{BTreeMap, HashMap}, fmt::Display, mem::replace, time::{Duration, Instant, SystemTime}
 };
 
 use tokio::sync::mpsc;
@@ -30,7 +27,7 @@ pub type DimensionPosition = BTreeMap<Name, Dimension>;
 /// Within the dimension position there is a collection of named measurements; we'll store the aggregated view of these
 pub type MeasurementAggregationMap = HashMap<Name, Aggregation>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum DistributionMode {
     /// Follows the opentelemetry standard for histogram buckets.
     ExponentialHistogram {
@@ -42,6 +39,16 @@ pub enum DistributionMode {
     /// Goodmetrics downstream, and timescaledb via timescaledb_toolkit.
     /// You should prefer t-digests when they are available to you :-)
     TDigest,
+}
+
+impl Display for DistributionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DistributionMode::ExponentialHistogram { max_buckets: _ } => f.write_str("exponential_histogram"),
+            DistributionMode::Histogram => f.write_str("histogram"),
+            DistributionMode::TDigest => f.write_str("t_digest"),
+        }
+    }
 }
 
 pub type SleepFunction = dyn Fn(Duration) + Send + Sync;

--- a/lib/src/pipeline/aggregator.rs
+++ b/lib/src/pipeline/aggregator.rs
@@ -1,5 +1,9 @@
 use std::{
-    cmp::min, collections::{BTreeMap, HashMap}, fmt::Display, mem::replace, time::{Duration, Instant, SystemTime}
+    cmp::min,
+    collections::{BTreeMap, HashMap},
+    fmt::Display,
+    mem::replace,
+    time::{Duration, Instant, SystemTime},
 };
 
 use tokio::sync::mpsc;
@@ -11,7 +15,8 @@ use crate::{
 
 use super::{
     aggregation::{
-        exponential_histogram::ExponentialHistogram, histogram::Histogram, online_tdigest::OnlineTdigest, statistic_set::StatisticSet, Aggregation
+        exponential_histogram::ExponentialHistogram, histogram::Histogram,
+        online_tdigest::OnlineTdigest, statistic_set::StatisticSet, Aggregation,
     },
     AbsorbDistribution,
 };
@@ -30,9 +35,7 @@ pub type MeasurementAggregationMap = HashMap<Name, Aggregation>;
 #[derive(Debug, Clone, Copy)]
 pub enum DistributionMode {
     /// Follows the opentelemetry standard for histogram buckets.
-    ExponentialHistogram {
-        max_buckets: u16,
-    },
+    ExponentialHistogram { max_buckets: u16 },
     /// Less space-efficient, less performant, but easy to understand.
     Histogram,
     /// Fancy sparse sketch distributions. Currently only compatible with
@@ -44,7 +47,9 @@ pub enum DistributionMode {
 impl Display for DistributionMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DistributionMode::ExponentialHistogram { max_buckets: _ } => f.write_str("exponential_histogram"),
+            DistributionMode::ExponentialHistogram { max_buckets: _ } => {
+                f.write_str("exponential_histogram")
+            }
             DistributionMode::Histogram => f.write_str("histogram"),
             DistributionMode::TDigest => f.write_str("t_digest"),
         }
@@ -259,7 +264,12 @@ where
                         accumulate_tdigest(measurements_map, name, distribution);
                     }
                     DistributionMode::ExponentialHistogram { max_buckets } => {
-                        accumulate_exponential_histogram(measurements_map, name, distribution, max_buckets)
+                        accumulate_exponential_histogram(
+                            measurements_map,
+                            name,
+                            distribution,
+                            max_buckets,
+                        )
                     }
                 },
             });
@@ -307,8 +317,12 @@ fn accumulate_exponential_histogram(
     match measurements_map
         .entry(name)
         // TODO: decide what to do with dynamic Scale scaling
-        .or_insert_with(|| Aggregation::ExponentialHistogram(ExponentialHistogram::new_with_max_buckets(2, max_buckets)))
-    {
+        .or_insert_with(|| {
+            Aggregation::ExponentialHistogram(ExponentialHistogram::new_with_max_buckets(
+                2,
+                max_buckets,
+            ))
+        }) {
         Aggregation::StatisticSet(_s) => {
             log::error!("conflicting measurement and distribution name")
         }


### PR DESCRIPTION
A basic implementation with fixed scale. 2 is recommended until
dynamic scaling is implemented. A benchmark is also added, and
some basic conversion to goodmetrics protocol is in place. The
aggregation benchmark now compares the different aggregation
formats in each run, and does fewer thread scenarios by default.

Exponential histograms follow [the opentelemetry standard](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram), for better
or for worse. When the `DistributionMode` is set to
`ExponentialHistogram`, the OpentelemetryDownstream will send
otlp ExponentialHistograms. The goodmetrics downstream will still
just send the normal map histograms, with rounded thresholds.

![image](https://github.com/kvc0/goodmetrics_rs/assets/3454741/4e86492d-24ea-4fe2-b8ee-cd79e4010a86)
