### PR TITLE
support lambda environments with a non preaggregation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ anything.
 For that case, use `lambda_metrics`. Each `Metrics` is converted to a wire batch the moment it is
 recorded (no time-window aggregation) and buffered; you flush the buffer at the end of each
 invocation, which sends everything and awaits delivery before you return. It works with both the
-goodmetrics and opentelemetry downstreams. See [the lambda example](./goodmetrics/examples/lambda.rs)
-for a complete setup, or run it with `cargo run --example lambda`.
+goodmetrics and opentelemetry downstreams.
 
 ```rust
 // Cold start: build these once and reuse them across invocations.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ metrics.distribution("some_continuous_value", instantaneous_network_bandwidth); 
 
 Once the `metrics` object is dropped from scope, it will export metrics to your desired ingest. If you need to publish metrics at some immediate point, you can manually `drop()` the object.
 
+### Lambda / immediate (unaggregated) pipeline
+
+The default pipeline accumulates metrics in an `Aggregator` and a background task drains it on
+an interval. That assumes the process keeps running between reports. In a lambda the process is
+frozen the instant your handler returns, so a background interval task can't reliably deliver
+anything.
+
+For that case, use `lambda_metrics`. Each `Metrics` is converted to a wire batch the moment it is
+recorded (no time-window aggregation) and buffered; you flush the buffer at the end of each
+invocation, which sends everything and awaits delivery before you return. It works with both the
+goodmetrics and opentelemetry downstreams. See [the lambda example](./goodmetrics/examples/lambda.rs)
+for a complete setup, or run it with `cargo run --example lambda`.
+
+```rust
+// Cold start: build these once and reuse them across invocations.
+let (sink, mut flusher) = lambda_metrics(downstream, GoodmetricsBatcher, DistributionMode::Histogram);
+let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, _> = MetricsFactory::new(sink);
+
+// Per invocation:
+{
+    let mut metrics = metrics_factory.record_scope("handler");
+    metrics.measurement("items", 3);
+} // converted and buffered here, on drop
+flusher.flush().await; // delivered before the handler returns
+```
+
+The buffer is also flushed best-effort when the `LambdaFlusher` is dropped (synchronously on a
+multi-threaded tokio runtime). The supported, guaranteed path is always to call `flush().await`
+yourself before returning.
+
 ### Record scope without measuring time
 
 Not every unit of work needs a measurement of how long it took to complete. Simply create a metrics object by calling `record_scope_with_behavior` and passing in your desired behavior.

--- a/goodmetrics/Cargo.toml
+++ b/goodmetrics/Cargo.toml
@@ -47,7 +47,7 @@ hyper-util                      = { workspace = true }
 log                             = { workspace = true }
 ordered-float                   = { workspace = true }
 prost                           = { workspace = true }
-tokio                           = { workspace = true }
+tokio                           = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
 tokio-rustls                    = { workspace = true }
 tokio-stream                    = { workspace = true }
 tonic                           = { workspace = true }

--- a/goodmetrics/src/downstream/goodmetrics_downstream.rs
+++ b/goodmetrics/src/downstream/goodmetrics_downstream.rs
@@ -14,7 +14,10 @@ use crate::{
     aggregation::{
         AbsorbDistribution, Aggregation, Centroid, Histogram, OnlineTdigest, StatisticSet,
     },
-    pipeline::{AggregatedMetricsMap, AggregationBatcher, DimensionedMeasurementsMap},
+    pipeline::{
+        AggregatedMetricsMap, AggregationBatcher, DimensionPosition, DimensionedMeasurementsMap,
+        DistributionMode, MetricsBatcher,
+    },
     proto::{
         self,
         goodmetrics::{metrics_client::MetricsClient, Datum, MetricsRequest},
@@ -146,6 +149,34 @@ impl AggregationBatcher for GoodmetricsBatcher {
                 as_datums(name, now, covered_time, dimensioned_measurements)
             })
             .collect()
+    }
+}
+
+impl MetricsBatcher for GoodmetricsBatcher {
+    type TBatch = Vec<Datum>;
+
+    fn batch_unaggregated(
+        &mut self,
+        now: SystemTime,
+        _covered_time: Duration,
+        _distribution_mode: DistributionMode,
+        name: Name,
+        dimensions: DimensionPosition,
+        measurements: Vec<(Name, Measurement)>,
+    ) -> Self::TBatch {
+        // One recording becomes one datum.
+        vec![Datum {
+            metric: name.to_string(),
+            unix_nanos: now.nanos_since_epoch(),
+            dimensions: dimensions
+                .into_iter()
+                .map(|(name, dimension)| (name.into(), dimension.into()))
+                .collect(),
+            measurements: measurements
+                .into_iter()
+                .map(|(name, measurement)| (name.into(), measurement.into()))
+                .collect(),
+        }]
     }
 }
 

--- a/goodmetrics/src/downstream/goodmetrics_downstream.rs
+++ b/goodmetrics/src/downstream/goodmetrics_downstream.rs
@@ -22,7 +22,7 @@ use crate::{
     types::{Dimension, Distribution, Measurement, Name, Observation},
 };
 
-use super::{EpochTime, StdError};
+use super::{EpochTime, MetricsSender, StdError};
 
 /// A downstream that sends metrics to a `goodmetricsd` or other goodmetrics grpc server.
 pub struct GoodmetricsDownstream<TChannel> {
@@ -71,29 +71,34 @@ where
             interval.tick().await;
             // Send as quickly as possible while there are more batches
             while let Some(batch) = pin!(&mut receiver).next().await {
-                let result = self
-                    .client
-                    .send_metrics(self.request(MetricsRequest {
-                        shared_dimensions: self.shared_dimensions.clone(),
-                        metrics: batch,
-                    }))
-                    .await;
-                match result {
-                    Ok(success) => {
-                        log::debug!("sent metrics: {success:?}");
-                    }
-                    Err(err) => {
-                        if !err.metadata().is_empty() {
-                            log::error!(
-                                "failed to send metrics: {err}. Metadata: {:?}",
-                                err.metadata()
-                            );
-                        }
-                        log::error!("failed to send metrics: {err:?}")
-                    }
-                };
+                self.send_one(batch).await;
             }
         }
+    }
+
+    /// Send a single batch in one request, awaiting the response. Errors are logged.
+    async fn send_one(&mut self, batch: Vec<Datum>) {
+        let result = self
+            .client
+            .send_metrics(self.request(MetricsRequest {
+                shared_dimensions: self.shared_dimensions.clone(),
+                metrics: batch,
+            }))
+            .await;
+        match result {
+            Ok(success) => {
+                log::debug!("sent metrics: {success:?}");
+            }
+            Err(err) => {
+                if !err.metadata().is_empty() {
+                    log::error!(
+                        "failed to send metrics: {err}. Metadata: {:?}",
+                        err.metadata()
+                    );
+                }
+                log::error!("failed to send metrics: {err:?}")
+            }
+        };
     }
 
     fn request<T>(&self, request: T) -> tonic::Request<T> {
@@ -102,6 +107,24 @@ where
             request.metadata_mut().insert(*header, value.clone());
         }
         request
+    }
+}
+
+impl<TChannel> MetricsSender for GoodmetricsDownstream<TChannel>
+where
+    TChannel: tonic::client::GrpcService<tonic::body::Body> + Send,
+    TChannel::Future: Send,
+    TChannel::Error: Into<StdError>,
+    TChannel::ResponseBody: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    <TChannel::ResponseBody as http_body::Body>::Error: Into<StdError> + Send,
+{
+    type Batch = Vec<Datum>;
+
+    fn send_batch(
+        &mut self,
+        batch: Self::Batch,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(self.send_one(batch))
     }
 }
 

--- a/goodmetrics/src/downstream/mod.rs
+++ b/goodmetrics/src/downstream/mod.rs
@@ -1,5 +1,7 @@
 //! Types related to emitting metrics to collectors
 
+use std::future::Future;
+use std::pin::Pin;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod channel_connection;
@@ -11,6 +13,17 @@ pub use goodmetrics_downstream::{GoodmetricsBatcher, GoodmetricsDownstream};
 pub use opentelemetry_downstream::{OpenTelemetryDownstream, OpentelemetryBatcher};
 
 pub(crate) type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// A downstream that can send a single batch of metrics in one request, awaiting
+/// delivery. In use by the immediate lambda pipeline, used to flush buffered metrics on
+/// demand.
+pub trait MetricsSender {
+    /// The wire batch type this sender accepts.
+    type Batch: Send;
+
+    /// Send one batch downstream, resolving when the request completes.
+    fn send_batch(&mut self, batch: Self::Batch) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+}
 
 /// A provider of unix epoch nanos
 pub trait EpochTime {

--- a/goodmetrics/src/downstream/opentelemetry_downstream.rs
+++ b/goodmetrics/src/downstream/opentelemetry_downstream.rs
@@ -24,8 +24,8 @@ use crate::{
     proto::opentelemetry::{metrics::v1::Gauge, resource::v1::Resource},
 };
 use crate::{
-    aggregation::{bucket_10_below_2_sigfigs, Aggregation, StatisticSet},
-    pipeline::{DimensionPosition, DimensionedMeasurementsMap},
+    aggregation::{bucket_10_below_2_sigfigs, AbsorbDistribution, Aggregation, StatisticSet},
+    pipeline::{DimensionPosition, DimensionedMeasurementsMap, DistributionMode, MetricsBatcher},
     proto::opentelemetry::{
         self,
         collector::metrics::v1::{
@@ -37,7 +37,7 @@ use crate::{
             ScopeMetrics,
         },
     },
-    types::{Dimension, Name},
+    types::{Dimension, Distribution, Measurement, Name, Observation},
 };
 
 use super::{EpochTime, MetricsSender, StdError};
@@ -202,6 +202,136 @@ impl AggregationBatcher for OpentelemetryBatcher {
                 as_metrics(name, now, covered_time, dimensioned_measurements)
             })
             .collect()
+    }
+}
+
+impl MetricsBatcher for OpentelemetryBatcher {
+    type TBatch = Vec<Metric>;
+
+    fn batch_unaggregated(
+        &mut self,
+        now: SystemTime,
+        covered_time: Duration,
+        distribution_mode: DistributionMode,
+        name: Name,
+        dimensions: DimensionPosition,
+        measurements: Vec<(Name, Measurement)>,
+    ) -> Self::TBatch {
+        // One recording becomes one datum.
+        let otel_dimensions = as_otel_dimensions(dimensions);
+        measurements
+            .into_iter()
+            .map(|(measurement_name, measurement)| {
+                let full_measurement_name = format!("{name}_{measurement_name}");
+                match measurement {
+                    Measurement::Observation(observation) => as_otel_gauge(
+                        full_measurement_name,
+                        now,
+                        covered_time,
+                        &otel_dimensions,
+                        observation_to_value(&observation),
+                    ),
+                    Measurement::Distribution(distribution) => as_otel_distribution(
+                        full_measurement_name,
+                        now,
+                        covered_time,
+                        distribution_mode,
+                        otel_dimensions.clone(),
+                        distribution,
+                    ),
+                    Measurement::Sum(sum) => as_otel_sum(
+                        Sum { sum },
+                        &full_measurement_name,
+                        now,
+                        covered_time,
+                        &otel_dimensions,
+                    ),
+                }
+            })
+            .collect()
+    }
+}
+
+fn observation_to_value(
+    observation: &Observation,
+) -> opentelemetry::metrics::v1::number_data_point::Value {
+    match observation {
+        Observation::I64(n) => (*n).into(),
+        Observation::I32(n) => (*n as i64).into(),
+        Observation::U64(n) => (*n).into(),
+        Observation::U32(n) => (*n as u64).into(),
+        Observation::F64(n) => (*n).into(),
+        Observation::F32(n) => (*n as f64).into(),
+    }
+}
+
+/// A single raw value sent as an opentelemetry gauge.
+fn as_otel_gauge(
+    full_measurement_name: String,
+    timestamp: SystemTime,
+    duration: Duration,
+    attributes: &[KeyValue],
+    value: opentelemetry::metrics::v1::number_data_point::Value,
+) -> Metric {
+    let timestamp_nanos = timestamp.nanos_since_epoch();
+    let start_nanos = timestamp_nanos - duration.as_nanos() as u64;
+    Metric {
+        name: full_measurement_name,
+        data: Some(opentelemetry::metrics::v1::metric::Data::Gauge(Gauge {
+            data_points: vec![new_number_data_point(
+                timestamp_nanos,
+                start_nanos,
+                attributes,
+                value,
+            )],
+        })),
+        description: "".into(),
+        unit: "1".into(),
+    }
+}
+
+/// A single recorded distribution rendered as a histogram, per the distribution mode.
+fn as_otel_distribution(
+    full_measurement_name: String,
+    timestamp: SystemTime,
+    duration: Duration,
+    distribution_mode: DistributionMode,
+    attributes: Vec<KeyValue>,
+    distribution: Distribution,
+) -> Metric {
+    let data = match distribution_mode {
+        DistributionMode::Histogram => {
+            let mut histogram = Histogram::default();
+            histogram.absorb(distribution);
+            opentelemetry::metrics::v1::metric::Data::Histogram(as_otel_histogram(
+                histogram, timestamp, duration, attributes,
+            ))
+        }
+        DistributionMode::ExponentialHistogram {
+            max_buckets,
+            desired_scale,
+        } => {
+            let mut exponential_histogram =
+                ExponentialHistogram::new_with_max_buckets(desired_scale, max_buckets);
+            exponential_histogram.absorb(distribution);
+            opentelemetry::metrics::v1::metric::Data::ExponentialHistogram(
+                as_otel_exponential_histogram(
+                    exponential_histogram,
+                    timestamp,
+                    duration,
+                    attributes,
+                ),
+            )
+        }
+        DistributionMode::TDigest => {
+            unimplemented!("tdigest for opentelemetry is not implemented")
+        }
+    };
+    Metric {
+        name: full_measurement_name,
+        data: Some(data),
+        description: "".into(),
+        unit: "1".into(),
     }
 }
 

--- a/goodmetrics/src/downstream/opentelemetry_downstream.rs
+++ b/goodmetrics/src/downstream/opentelemetry_downstream.rs
@@ -40,7 +40,7 @@ use crate::{
     types::{Dimension, Name},
 };
 
-use super::{EpochTime, StdError};
+use super::{EpochTime, MetricsSender, StdError};
 
 /// Goodmetrics only records "delta" data as that word is understood by opentelemetry.
 /// Goodmetrics records windows of aggregation_width and submits whatever was recorded
@@ -114,42 +114,47 @@ where
             interval.tick().await;
             // Send as quickly as possible while there are more batches
             while let Some(batch) = pin!(&mut receiver).next().await {
-                let result = self
-                    .client
-                    .export(self.request(ExportMetricsServiceRequest {
-                        resource_metrics: vec![ResourceMetrics {
-                            resource: self.shared_dimensions.as_ref().map(|dimensions| Resource {
-                                attributes: dimensions.clone(),
-                                dropped_attributes_count: 0,
-                            }),
-                            schema_url: "".to_string(),
-                            scope_metrics: vec![ScopeMetrics {
-                                scope: Some(InstrumentationScope {
-                                    name: "goodmetrics".to_string(),
-                                    version: VERSION.unwrap_or("unknown").to_string(),
-                                }),
-                                schema_url: "".to_string(),
-                                metrics: batch,
-                            }],
-                        }],
-                    }))
-                    .await;
-                match result {
-                    Ok(success) => {
-                        log::debug!("sent metrics: {success:?}");
-                    }
-                    Err(err) => {
-                        if !err.metadata().is_empty() {
-                            log::error!(
-                                "failed to send metrics: {err}. Metadata: {:?}",
-                                err.metadata()
-                            );
-                        }
-                        log::error!("failed to send metrics: {err:?}")
-                    }
-                };
+                self.send_one(batch).await;
             }
         }
+    }
+
+    /// Send a single batch in one request, awaiting the response. Errors are logged.
+    async fn send_one(&mut self, batch: Vec<Metric>) {
+        let result = self
+            .client
+            .export(self.request(ExportMetricsServiceRequest {
+                resource_metrics: vec![ResourceMetrics {
+                    resource: self.shared_dimensions.as_ref().map(|dimensions| Resource {
+                        attributes: dimensions.clone(),
+                        dropped_attributes_count: 0,
+                    }),
+                    schema_url: "".to_string(),
+                    scope_metrics: vec![ScopeMetrics {
+                        scope: Some(InstrumentationScope {
+                            name: "goodmetrics".to_string(),
+                            version: VERSION.unwrap_or("unknown").to_string(),
+                        }),
+                        schema_url: "".to_string(),
+                        metrics: batch,
+                    }],
+                }],
+            }))
+            .await;
+        match result {
+            Ok(success) => {
+                log::debug!("sent metrics: {success:?}");
+            }
+            Err(err) => {
+                if !err.metadata().is_empty() {
+                    log::error!(
+                        "failed to send metrics: {err}. Metadata: {:?}",
+                        err.metadata()
+                    );
+                }
+                log::error!("failed to send metrics: {err:?}")
+            }
+        };
     }
 
     fn request<T>(&self, request: T) -> tonic::Request<T> {
@@ -158,6 +163,24 @@ where
             request.metadata_mut().insert(header.clone(), value.clone());
         }
         request
+    }
+}
+
+impl<TChannel> MetricsSender for OpenTelemetryDownstream<TChannel>
+where
+    TChannel: tonic::client::GrpcService<tonic::body::Body> + Send,
+    TChannel::Future: Send,
+    TChannel::Error: Into<StdError>,
+    TChannel::ResponseBody: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    <TChannel::ResponseBody as http_body::Body>::Error: Into<StdError> + Send,
+{
+    type Batch = Vec<Metric>;
+
+    fn send_batch(
+        &mut self,
+        batch: Self::Batch,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(self.send_one(batch))
     }
 }
 

--- a/goodmetrics/src/pipeline/aggregator.rs
+++ b/goodmetrics/src/pipeline/aggregator.rs
@@ -277,65 +277,81 @@ where
         Some(batcher.batch_aggregations(timestamp, duration, &mut self.map))
     }
 
-    fn aggregate_metrics(&mut self, mut sunk_metrics: TMetricsRef) {
-        let metrics_name = replace(
-            &mut sunk_metrics.as_mut().metrics_name,
-            Name::Str("_uninitialized_"),
+    fn aggregate_metrics(&mut self, sunk_metrics: TMetricsRef) {
+        aggregate_metrics_into(
+            &mut self.map,
+            self.distribution_mode,
+            &mut self.cached_position,
+            sunk_metrics,
         );
-        let (dimensions, measurements) = sunk_metrics.as_mut().drain();
-
-        let dimensioned_measurements_map: &mut DimensionedMeasurementsMap =
-            match self.map.get_mut(&metrics_name) {
-                Some(existing) => existing,
-                None => {
-                    self.map.insert(metrics_name.clone(), Default::default());
-                    self.map
-                        .get_mut(&metrics_name)
-                        .expect("I just inserted this 1 line above")
-                }
-            };
-
-        self.cached_position.extend(dimensions.drain()); // Use the cached memory
-        let measurements_map: &mut MeasurementAggregationMap =
-            match dimensioned_measurements_map.get_mut(&self.cached_position) {
-                Some(map) => map,
-                None => {
-                    dimensioned_measurements_map
-                        .insert(self.cached_position.clone(), Default::default());
-                    dimensioned_measurements_map
-                        .get_mut(&self.cached_position)
-                        .expect("I just inserted this 1 line above")
-                }
-            };
-        self.cached_position.clear(); // Return the cached memory
-
-        measurements
-            .drain()
-            .for_each(|(name, measurement)| match measurement {
-                Measurement::Observation(observation) => {
-                    accumulate_statisticset(measurements_map, name, observation);
-                }
-                Measurement::Distribution(distribution) => match self.distribution_mode {
-                    DistributionMode::Histogram => {
-                        accumulate_histogram(measurements_map, name, distribution);
-                    }
-                    DistributionMode::TDigest => {
-                        accumulate_tdigest(measurements_map, name, distribution);
-                    }
-                    DistributionMode::ExponentialHistogram {
-                        max_buckets,
-                        desired_scale,
-                    } => accumulate_exponential_histogram(
-                        measurements_map,
-                        name,
-                        distribution,
-                        max_buckets,
-                        desired_scale,
-                    ),
-                },
-                Measurement::Sum(sum) => accumulate_sum(measurements_map, name, sum),
-            });
     }
+}
+
+/// Fold a single metrics object into an aggregation map.
+
+pub(crate) fn aggregate_metrics_into<TMetricsRef>(
+    map: &mut AggregatedMetricsMap,
+    distribution_mode: DistributionMode,
+    cached_position: &mut DimensionPosition,
+    mut sunk_metrics: TMetricsRef,
+) where
+    TMetricsRef: MetricsRef,
+{
+    let metrics_name = replace(
+        &mut sunk_metrics.as_mut().metrics_name,
+        Name::Str("_uninitialized_"),
+    );
+    let (dimensions, measurements) = sunk_metrics.as_mut().drain();
+
+    let dimensioned_measurements_map: &mut DimensionedMeasurementsMap =
+        match map.get_mut(&metrics_name) {
+            Some(existing) => existing,
+            None => {
+                map.insert(metrics_name.clone(), Default::default());
+                map.get_mut(&metrics_name)
+                    .expect("I just inserted this 1 line above")
+            }
+        };
+
+    cached_position.extend(dimensions.drain()); // Use the cached memory
+    let measurements_map: &mut MeasurementAggregationMap =
+        match dimensioned_measurements_map.get_mut(cached_position) {
+            Some(map) => map,
+            None => {
+                dimensioned_measurements_map.insert(cached_position.clone(), Default::default());
+                dimensioned_measurements_map
+                    .get_mut(cached_position)
+                    .expect("I just inserted this 1 line above")
+            }
+        };
+    cached_position.clear(); // Return the cached memory
+
+    measurements
+        .drain()
+        .for_each(|(name, measurement)| match measurement {
+            Measurement::Observation(observation) => {
+                accumulate_statisticset(measurements_map, name, observation);
+            }
+            Measurement::Distribution(distribution) => match distribution_mode {
+                DistributionMode::Histogram => {
+                    accumulate_histogram(measurements_map, name, distribution);
+                }
+                DistributionMode::TDigest => {
+                    accumulate_tdigest(measurements_map, name, distribution);
+                }
+                DistributionMode::ExponentialHistogram {
+                    max_buckets,
+                    desired_scale,
+                } => accumulate_exponential_histogram(
+                    measurements_map,
+                    name,
+                    distribution,
+                    max_buckets,
+                    desired_scale,
+                ),
+            },
+            Measurement::Sum(sum) => accumulate_sum(measurements_map, name, sum),
+        });
 }
 
 fn accumulate_histogram(

--- a/goodmetrics/src/pipeline/aggregator.rs
+++ b/goodmetrics/src/pipeline/aggregator.rs
@@ -288,7 +288,6 @@ where
 }
 
 /// Fold a single metrics object into an aggregation map.
-
 pub(crate) fn aggregate_metrics_into<TMetricsRef>(
     map: &mut AggregatedMetricsMap,
     distribution_mode: DistributionMode,

--- a/goodmetrics/src/pipeline/aggregator.rs
+++ b/goodmetrics/src/pipeline/aggregator.rs
@@ -138,6 +138,26 @@ pub trait AggregationBatcher {
     ) -> Self::TBatch;
 }
 
+/// Converts a single recorded metric straight into a wire batch, with no
+/// time-window aggregation. Each observation becomes one raw datapoint and each
+/// distribution becomes one histogram. This is the per-record path used by the
+/// lambda pipeline.
+pub trait MetricsBatcher {
+    /// Type of batch this batcher produces.
+    type TBatch;
+
+    /// Convert one recorded metric's dimensions and measurements into a batch.
+    fn batch_unaggregated(
+        &mut self,
+        now: SystemTime,
+        covered_time: Duration,
+        distribution_mode: DistributionMode,
+        name: Name,
+        dimensions: DimensionPosition,
+        measurements: Vec<(Name, Measurement)>,
+    ) -> Self::TBatch;
+}
+
 /// Aggregates metrics and presents a pollable interface for creating batches of metrics.
 pub struct Aggregator<TMetricsRef> {
     metrics_queue: std::sync::mpsc::Receiver<TMetricsRef>,

--- a/goodmetrics/src/pipeline/lambda.rs
+++ b/goodmetrics/src/pipeline/lambda.rs
@@ -1,30 +1,21 @@
-//! An immediate, unaggregated metrics pipeline for serverless / lambda environments.
-//!
-//! The default goodmetrics pipeline accumulates metrics into an
-//! [`Aggregator`](crate::pipeline::Aggregator) and a background task drains it on
-//! an interval. That model assumes the process keeps running between reports. In a
-//! lambda the process is frozen the instant your handler returns, so a background
-//! interval task can't reliably deliver anything.
-//!
-//! This module flips the model around: each `Metrics` is converted to a wire batch
-//! the moment it is recorded (no time-window aggregation) and buffered. You then
-//! [`flush`](LambdaFlusher::flush) the buffer at the end of your handler, which
-//! sends everything downstream and awaits delivery before you return. The buffer is
-//! also flushed best-effort when the [`LambdaFlusher`] is dropped.
-//!
+// For use in monitoring environments where preaggregation is not necessary; lambda env
+// require no preaggregation, instead we'd like to send metrics on a per-record basis.
+// Each recorded Metrics becomes its own batch and each measurement is sent as an
+// individual datapoint.
+//
 //! ```no_run
 //! # async fn example() {
 //! use goodmetrics::MetricsFactory;
 //! use goodmetrics::allocator::AlwaysNewMetricsAllocator;
-//! use goodmetrics::downstream::{get_client, GoodmetricsBatcher, GoodmetricsDownstream};
+//! use goodmetrics::downstream::{get_client, OpentelemetryBatcher, OpenTelemetryDownstream};
 //! use goodmetrics::pipeline::{lambda_metrics, DistributionMode};
 //!
 //! // 1. Build a downstream as usual:
-//! let downstream = GoodmetricsDownstream::new(
+//! let downstream = OpenTelemetryDownstream::new_with_dimensions(
 //!     get_client(
 //!         "https://ingest.example.com",
 //!         || None,
-//!         goodmetrics::proto::goodmetrics::metrics_client::MetricsClient::with_origin,
+//!         goodmetrics::proto::opentelemetry::collector::metrics::v1::metrics_service_client::MetricsServiceClient::with_origin,
 //!     ).expect("channel"),
 //!     Some(("authorization", "token".parse().expect("header"))),
 //!     [("application", "example")],
@@ -33,7 +24,7 @@
 //! // 2. Wire up the immediate pipeline. Keep the factory and flusher around across
 //! //    invocations (e.g. in your cold-start setup).
 //! let (sink, mut flusher) =
-//!     lambda_metrics(downstream, GoodmetricsBatcher, DistributionMode::Histogram);
+//!     lambda_metrics(downstream, OpentelemetryBatcher, DistributionMode::Histogram);
 //! let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, _> = MetricsFactory::new(sink);
 //!
 //! // 3. In each invocation, record metrics then flush before returning:
@@ -51,23 +42,23 @@ use std::time::SystemTime;
 
 use crate::allocator::MetricsRef;
 use crate::downstream::MetricsSender;
+use crate::types::Name;
 
-use super::aggregator::aggregate_metrics_into;
-use super::{AggregatedMetricsMap, AggregationBatcher, DimensionPosition, DistributionMode, Sink};
+use super::{DimensionPosition, DistributionMode, MetricsBatcher, Sink};
 
 /// Shared buffer of converted-but-not-yet-sent wire batches.
 type Buffer<TBatch> = Arc<Mutex<Vec<TBatch>>>;
 
 /// A Sink that converts each Metrics into a wire batch immediately, with no
-/// time-window aggregation, and buffers it until the paired LambdaFlusher sends
+/// time-window aggregation, buffers until the paired LambdaFlusher sends
 /// it.
-pub struct LambdaSink<TBatcher: AggregationBatcher> {
+pub struct LambdaSink<TBatcher: MetricsBatcher> {
     buffer: Buffer<TBatcher::TBatch>,
     batcher: Mutex<TBatcher>,
     distribution_mode: DistributionMode,
 }
 
-impl<TBatcher: AggregationBatcher> LambdaSink<TBatcher> {
+impl<TBatcher: MetricsBatcher> LambdaSink<TBatcher> {
     fn new(
         buffer: Buffer<TBatcher::TBatch>,
         batcher: TBatcher,
@@ -83,7 +74,7 @@ impl<TBatcher: AggregationBatcher> LambdaSink<TBatcher> {
 
 impl<TBatcher> Clone for LambdaSink<TBatcher>
 where
-    TBatcher: AggregationBatcher + Clone,
+    TBatcher: MetricsBatcher + Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -97,41 +88,42 @@ where
 impl<TMetricsRef, TBatcher> Sink<TMetricsRef> for LambdaSink<TBatcher>
 where
     TMetricsRef: MetricsRef,
-    TBatcher: AggregationBatcher,
+    TBatcher: MetricsBatcher,
 {
-    fn accept(&self, to_sink: TMetricsRef) {
-        // Use the recorded scope's elapsed time as the window this single batch
-        // covers, so downstreams that care about start/end timestamps get a
-        // sensible (non-zero) interval.
+    fn accept(&self, mut to_sink: TMetricsRef) {
+        // Use the recorded scope's elapsed time as the window for single batchs
         let covered_time = to_sink.as_ref().start_time.elapsed();
 
-        let mut map = AggregatedMetricsMap::default();
-        let mut position = DimensionPosition::default();
-        aggregate_metrics_into(&mut map, self.distribution_mode, &mut position, to_sink);
+        let metrics = to_sink.as_mut();
+        let name = std::mem::replace(&mut metrics.metrics_name, Name::Str("_uninitialized_"));
+        let (dimensions, measurements) = metrics.drain();
+        let dimensions: DimensionPosition = dimensions.drain().collect();
+        let measurements: Vec<_> = measurements.drain().collect();
 
         let batch = self
             .batcher
             .lock()
             .expect("local mutex")
-            .batch_aggregations(SystemTime::now(), covered_time, &mut map);
+            .batch_unaggregated(
+                SystemTime::now(),
+                covered_time,
+                self.distribution_mode,
+                name,
+                dimensions,
+                measurements,
+            );
         self.buffer.lock().expect("local mutex").push(batch);
     }
 }
 
-/// Sends batches buffered by a [`LambdaSink`] downstream on demand.
-///
-/// Call [`flush`](Self::flush) at the end of each invocation to deliver everything
-/// recorded so far and await delivery. Anything still buffered when the flusher is
-/// dropped is flushed best-effort (see [`Drop`]).
+/// Sends batches buffered by a LambdaSink downstream on demand.
 pub struct LambdaFlusher<TSender: MetricsSender> {
     buffer: Buffer<TSender::Batch>,
     downstream: TSender,
 }
 
 impl<TSender: MetricsSender> LambdaFlusher<TSender> {
-    /// Send every batch buffered so far, awaiting delivery. Cheap and safe to call
-    /// when nothing is buffered, so call it unconditionally at the end of each
-    /// invocation.
+    /// Send every batch buffered so far, awaiting delivery.=
     pub async fn flush(&mut self) {
         let batches = std::mem::take(&mut *self.buffer.lock().expect("local mutex"));
         for batch in batches {
@@ -147,28 +139,11 @@ impl<TSender: MetricsSender> Drop for LambdaFlusher<TSender> {
             .lock()
             .map(|buffer| !buffer.is_empty())
             .unwrap_or(false);
-        if !has_unflushed {
-            return;
-        }
-
-        // Drop is synchronous but flushing is async. We can only drive it to
-        // completion on a multi-threaded runtime via block_in_place; everywhere
-        // else we warn rather than risk a panic or a silent drop. The supported
-        // path is always to call flush().await yourself before returning.
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => match handle.runtime_flavor() {
-                tokio::runtime::RuntimeFlavor::MultiThread => {
-                    tokio::task::block_in_place(|| handle.block_on(self.flush()));
-                }
-                _ => log::warn!(
-                    "LambdaFlusher dropped with unflushed metrics on a current-thread runtime; \
-                     call flush().await before returning to guarantee delivery"
-                ),
-            },
-            Err(_) => log::warn!(
-                "LambdaFlusher dropped with unflushed metrics outside of a tokio runtime; \
-                 these metrics were not sent"
-            ),
+        if has_unflushed {
+            log::error!(
+                "LambdaFlusher dropped with unflushed metrics, \
+                call flush().await before returning to guarantee delivery"
+            )
         }
     }
 }
@@ -186,7 +161,7 @@ pub fn lambda_metrics<TSender, TBatcher>(
 ) -> (LambdaSink<TBatcher>, LambdaFlusher<TSender>)
 where
     TSender: MetricsSender,
-    TBatcher: AggregationBatcher<TBatch = TSender::Batch>,
+    TBatcher: MetricsBatcher<TBatch = TSender::Batch>,
 {
     let buffer: Buffer<TSender::Batch> = Default::default();
     (
@@ -202,9 +177,9 @@ mod test {
 
     use crate::{
         allocator::AlwaysNewMetricsAllocator,
-        downstream::{GoodmetricsBatcher, MetricsSender},
+        downstream::{GoodmetricsBatcher, MetricsSender, OpentelemetryBatcher},
         pipeline::DistributionMode,
-        proto::goodmetrics::Datum,
+        proto::{goodmetrics::Datum, opentelemetry::metrics::v1::Metric},
         MetricsFactory,
     };
 
@@ -217,6 +192,22 @@ mod test {
     }
     impl MetricsSender for RecordingSender {
         type Batch = Vec<Datum>;
+        fn send_batch(
+            &mut self,
+            batch: Self::Batch,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            self.sent.lock().unwrap().push(batch);
+            Box::pin(async {})
+        }
+    }
+
+    /// As [`RecordingSender`], but for the opentelemetry wire type.
+    #[derive(Default, Clone)]
+    struct RecordingOtelSender {
+        sent: Arc<Mutex<Vec<Vec<Metric>>>>,
+    }
+    impl MetricsSender for RecordingOtelSender {
+        type Batch = Vec<Metric>;
         fn send_batch(
             &mut self,
             batch: Self::Batch,
@@ -270,6 +261,59 @@ mod test {
             sent.lock().unwrap().len(),
             "three recordings stay as three separate, unaggregated batches"
         );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn opentelemetry_observation_is_a_single_raw_gauge() {
+        use crate::proto::opentelemetry::metrics::v1::metric::Data;
+
+        let downstream = RecordingOtelSender::default();
+        let sent = downstream.sent.clone();
+        let (sink, mut flusher): (LambdaSink<OpentelemetryBatcher>, _) = lambda_metrics(
+            downstream,
+            OpentelemetryBatcher,
+            DistributionMode::Histogram,
+        );
+        let factory: MetricsFactory<AlwaysNewMetricsAllocator, _> = MetricsFactory::new(sink);
+
+        {
+            let mut metrics = factory.record_scope("handler");
+            metrics.measurement("items", 3);
+        }
+        flusher.flush().await;
+
+        let sent = sent.lock().unwrap();
+        assert_eq!(1, sent.len(), "one invocation produced one batch");
+        let batch = &sent[0];
+
+        // The observation must be one raw gauge, not expanded into a four-part
+        // min/max/sum/count statistic set as the aggregating pipeline would do.
+        // (record_scope also records a `totaltime` distribution, so the batch has
+        // more than just this metric.)
+        let items: Vec<_> = batch
+            .iter()
+            .filter(|m| m.name.starts_with("handler_items"))
+            .collect();
+        assert_eq!(
+            vec!["handler_items"],
+            items.iter().map(|m| m.name.as_str()).collect::<Vec<_>>(),
+            "the observation is one metric named handler_items, with no _min/_max/_sum/_count"
+        );
+        match items[0].data.as_ref().expect("data") {
+            Data::Gauge(gauge) => {
+                assert_eq!(
+                    1,
+                    gauge.data_points.len(),
+                    "one datapoint for the one value"
+                );
+                use crate::proto::opentelemetry::metrics::v1::number_data_point::Value;
+                assert!(
+                    matches!(gauge.data_points[0].value, Some(Value::AsInt(3))),
+                    "the raw recorded value is preserved as an integer gauge"
+                );
+            }
+            other => panic!("observation should become a gauge, got {other:?}"),
+        }
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]

--- a/goodmetrics/src/pipeline/lambda.rs
+++ b/goodmetrics/src/pipeline/lambda.rs
@@ -1,0 +1,301 @@
+//! An immediate, unaggregated metrics pipeline for serverless / lambda environments.
+//!
+//! The default goodmetrics pipeline accumulates metrics into an
+//! [`Aggregator`](crate::pipeline::Aggregator) and a background task drains it on
+//! an interval. That model assumes the process keeps running between reports. In a
+//! lambda the process is frozen the instant your handler returns, so a background
+//! interval task can't reliably deliver anything.
+//!
+//! This module flips the model around: each `Metrics` is converted to a wire batch
+//! the moment it is recorded (no time-window aggregation) and buffered. You then
+//! [`flush`](LambdaFlusher::flush) the buffer at the end of your handler, which
+//! sends everything downstream and awaits delivery before you return. The buffer is
+//! also flushed best-effort when the [`LambdaFlusher`] is dropped.
+//!
+//! ```no_run
+//! # async fn example() {
+//! use goodmetrics::MetricsFactory;
+//! use goodmetrics::allocator::AlwaysNewMetricsAllocator;
+//! use goodmetrics::downstream::{get_client, GoodmetricsBatcher, GoodmetricsDownstream};
+//! use goodmetrics::pipeline::{lambda_metrics, DistributionMode};
+//!
+//! // 1. Build a downstream as usual:
+//! let downstream = GoodmetricsDownstream::new(
+//!     get_client(
+//!         "https://ingest.example.com",
+//!         || None,
+//!         goodmetrics::proto::goodmetrics::metrics_client::MetricsClient::with_origin,
+//!     ).expect("channel"),
+//!     Some(("authorization", "token".parse().expect("header"))),
+//!     [("application", "example")],
+//! );
+//!
+//! // 2. Wire up the immediate pipeline. Keep the factory and flusher around across
+//! //    invocations (e.g. in your cold-start setup).
+//! let (sink, mut flusher) =
+//!     lambda_metrics(downstream, GoodmetricsBatcher, DistributionMode::Histogram);
+//! let metrics_factory: MetricsFactory<AlwaysNewMetricsAllocator, _> = MetricsFactory::new(sink);
+//!
+//! // 3. In each invocation, record metrics then flush before returning:
+//! {
+//!     let mut metrics = metrics_factory.record_scope("handler");
+//!     metrics.dimension("route", "/health");
+//!     metrics.measurement("items", 3);
+//! } // metrics is converted and buffered here, on drop
+//! flusher.flush().await; // delivered before the handler returns
+//! # }
+//! ```
+
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use crate::allocator::MetricsRef;
+use crate::downstream::MetricsSender;
+
+use super::aggregator::aggregate_metrics_into;
+use super::{AggregatedMetricsMap, AggregationBatcher, DimensionPosition, DistributionMode, Sink};
+
+/// Shared buffer of converted-but-not-yet-sent wire batches.
+type Buffer<TBatch> = Arc<Mutex<Vec<TBatch>>>;
+
+/// A Sink that converts each Metrics into a wire batch immediately, with no
+/// time-window aggregation, and buffers it until the paired LambdaFlusher sends
+/// it.
+pub struct LambdaSink<TBatcher: AggregationBatcher> {
+    buffer: Buffer<TBatcher::TBatch>,
+    batcher: Mutex<TBatcher>,
+    distribution_mode: DistributionMode,
+}
+
+impl<TBatcher: AggregationBatcher> LambdaSink<TBatcher> {
+    fn new(
+        buffer: Buffer<TBatcher::TBatch>,
+        batcher: TBatcher,
+        distribution_mode: DistributionMode,
+    ) -> Self {
+        Self {
+            buffer,
+            batcher: Mutex::new(batcher),
+            distribution_mode,
+        }
+    }
+}
+
+impl<TBatcher> Clone for LambdaSink<TBatcher>
+where
+    TBatcher: AggregationBatcher + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            buffer: self.buffer.clone(),
+            batcher: Mutex::new(self.batcher.lock().expect("local mutex").clone()),
+            distribution_mode: self.distribution_mode,
+        }
+    }
+}
+
+impl<TMetricsRef, TBatcher> Sink<TMetricsRef> for LambdaSink<TBatcher>
+where
+    TMetricsRef: MetricsRef,
+    TBatcher: AggregationBatcher,
+{
+    fn accept(&self, to_sink: TMetricsRef) {
+        // Use the recorded scope's elapsed time as the window this single batch
+        // covers, so downstreams that care about start/end timestamps get a
+        // sensible (non-zero) interval.
+        let covered_time = to_sink.as_ref().start_time.elapsed();
+
+        let mut map = AggregatedMetricsMap::default();
+        let mut position = DimensionPosition::default();
+        aggregate_metrics_into(&mut map, self.distribution_mode, &mut position, to_sink);
+
+        let batch = self
+            .batcher
+            .lock()
+            .expect("local mutex")
+            .batch_aggregations(SystemTime::now(), covered_time, &mut map);
+        self.buffer.lock().expect("local mutex").push(batch);
+    }
+}
+
+/// Sends batches buffered by a [`LambdaSink`] downstream on demand.
+///
+/// Call [`flush`](Self::flush) at the end of each invocation to deliver everything
+/// recorded so far and await delivery. Anything still buffered when the flusher is
+/// dropped is flushed best-effort (see [`Drop`]).
+pub struct LambdaFlusher<TSender: MetricsSender> {
+    buffer: Buffer<TSender::Batch>,
+    downstream: TSender,
+}
+
+impl<TSender: MetricsSender> LambdaFlusher<TSender> {
+    /// Send every batch buffered so far, awaiting delivery. Cheap and safe to call
+    /// when nothing is buffered, so call it unconditionally at the end of each
+    /// invocation.
+    pub async fn flush(&mut self) {
+        let batches = std::mem::take(&mut *self.buffer.lock().expect("local mutex"));
+        for batch in batches {
+            self.downstream.send_batch(batch).await;
+        }
+    }
+}
+
+impl<TSender: MetricsSender> Drop for LambdaFlusher<TSender> {
+    fn drop(&mut self) {
+        let has_unflushed = self
+            .buffer
+            .lock()
+            .map(|buffer| !buffer.is_empty())
+            .unwrap_or(false);
+        if !has_unflushed {
+            return;
+        }
+
+        // Drop is synchronous but flushing is async. We can only drive it to
+        // completion on a multi-threaded runtime via block_in_place; everywhere
+        // else we warn rather than risk a panic or a silent drop. The supported
+        // path is always to call flush().await yourself before returning.
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => match handle.runtime_flavor() {
+                tokio::runtime::RuntimeFlavor::MultiThread => {
+                    tokio::task::block_in_place(|| handle.block_on(self.flush()));
+                }
+                _ => log::warn!(
+                    "LambdaFlusher dropped with unflushed metrics on a current-thread runtime; \
+                     call flush().await before returning to guarantee delivery"
+                ),
+            },
+            Err(_) => log::warn!(
+                "LambdaFlusher dropped with unflushed metrics outside of a tokio runtime; \
+                 these metrics were not sent"
+            ),
+        }
+    }
+}
+
+/// Build an immediate lambda metrics pipeline: a LambdaSink to put behind a
+/// MetricsFactory and a LambdaFlusher to flush it.
+///
+/// The two share a buffer. The `batcher` and `downstream` must agree on the wire
+/// batch type, e.g. GoodmetricsBatcher with GoodmetricsDownstream,
+/// or OpentelemetryBatcher with OpenTelemetryDownstream.
+pub fn lambda_metrics<TSender, TBatcher>(
+    downstream: TSender,
+    batcher: TBatcher,
+    distribution_mode: DistributionMode,
+) -> (LambdaSink<TBatcher>, LambdaFlusher<TSender>)
+where
+    TSender: MetricsSender,
+    TBatcher: AggregationBatcher<TBatch = TSender::Batch>,
+{
+    let buffer: Buffer<TSender::Batch> = Default::default();
+    (
+        LambdaSink::new(buffer.clone(), batcher, distribution_mode),
+        LambdaFlusher { buffer, downstream },
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use std::sync::{Arc, Mutex};
+
+    use crate::{
+        allocator::AlwaysNewMetricsAllocator,
+        downstream::{GoodmetricsBatcher, MetricsSender},
+        pipeline::DistributionMode,
+        proto::goodmetrics::Datum,
+        MetricsFactory,
+    };
+
+    use super::{lambda_metrics, LambdaSink};
+
+    /// A MetricsSender that just records what it was handed, so we can assert on it.
+    #[derive(Default, Clone)]
+    struct RecordingSender {
+        sent: Arc<Mutex<Vec<Vec<Datum>>>>,
+    }
+    impl MetricsSender for RecordingSender {
+        type Batch = Vec<Datum>;
+        fn send_batch(
+            &mut self,
+            batch: Self::Batch,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            self.sent.lock().unwrap().push(batch);
+            Box::pin(async {})
+        }
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn records_immediately_and_flushes() {
+        let downstream = RecordingSender::default();
+        let sent = downstream.sent.clone();
+        let (sink, mut flusher): (LambdaSink<GoodmetricsBatcher>, _) =
+            lambda_metrics(downstream, GoodmetricsBatcher, DistributionMode::Histogram);
+        let factory: MetricsFactory<AlwaysNewMetricsAllocator, _> = MetricsFactory::new(sink);
+
+        // Nothing is sent until we flush, but recording buffers a batch immediately.
+        {
+            let mut metrics = factory.record_scope("test");
+            metrics.dimension("dim", "value");
+            metrics.measurement("count", 1);
+        }
+        assert!(sent.lock().unwrap().is_empty(), "nothing sent before flush");
+
+        flusher.flush().await;
+        let sent = sent.lock().unwrap();
+        assert_eq!(1, sent.len(), "one invocation produced one batch");
+        let batch = &sent[0];
+        assert_eq!(1, batch.len(), "one datum for the one recording");
+        assert_eq!("test", batch[0].metric);
+        assert!(batch[0].measurements.contains_key("count"));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn each_recording_is_its_own_unaggregated_batch() {
+        let downstream = RecordingSender::default();
+        let sent = downstream.sent.clone();
+        let (sink, mut flusher): (LambdaSink<GoodmetricsBatcher>, _) =
+            lambda_metrics(downstream, GoodmetricsBatcher, DistributionMode::Histogram);
+        let factory: MetricsFactory<AlwaysNewMetricsAllocator, _> = MetricsFactory::new(sink);
+
+        for i in 0..3 {
+            let mut metrics = factory.record_scope("test");
+            metrics.measurement("i", i);
+        }
+        flusher.flush().await;
+
+        assert_eq!(
+            3,
+            sent.lock().unwrap().len(),
+            "three recordings stay as three separate, unaggregated batches"
+        );
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+    async fn flushes_on_drop_when_flush_is_not_called() {
+        let downstream = RecordingSender::default();
+        let sent = downstream.sent.clone();
+        let (sink, flusher): (LambdaSink<GoodmetricsBatcher>, _) =
+            lambda_metrics(downstream, GoodmetricsBatcher, DistributionMode::Histogram);
+        let factory: MetricsFactory<AlwaysNewMetricsAllocator, _> = MetricsFactory::new(sink);
+
+        {
+            let mut metrics = factory.record_scope("test");
+            metrics.dimension("dim", "value");
+            metrics.measurement("count", 1);
+        }
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "nothing sent while buffered and flush() was never called"
+        );
+
+        // Never call flush(); dropping the flusher must deliver the buffered batch.
+        drop(flusher);
+
+        let sent = sent.lock().unwrap();
+        assert_eq!(1, sent.len(), "drop flushed the buffered batch");
+        assert_eq!("test", sent[0][0].metric);
+        assert!(sent[0][0].measurements.contains_key("count"));
+    }
+}

--- a/goodmetrics/src/pipeline/mod.rs
+++ b/goodmetrics/src/pipeline/mod.rs
@@ -13,7 +13,8 @@ mod stream_sink;
 
 pub use aggregator::{
     AggregatedMetricsMap, AggregationBatcher, Aggregator, DimensionPosition,
-    DimensionedMeasurementsMap, DistributionMode, MeasurementAggregationMap, TimeSource,
+    DimensionedMeasurementsMap, DistributionMode, MeasurementAggregationMap, MetricsBatcher,
+    TimeSource,
 };
 pub use lambda::{lambda_metrics, LambdaFlusher, LambdaSink};
 pub use logging_sink::LoggingSink;

--- a/goodmetrics/src/pipeline/mod.rs
+++ b/goodmetrics/src/pipeline/mod.rs
@@ -6,6 +6,7 @@ use futures::StreamExt;
 use futures_batch::ChunksTimeoutStreamExt;
 
 mod aggregator;
+mod lambda;
 mod logging_sink;
 mod serializing_sink;
 mod stream_sink;
@@ -14,6 +15,7 @@ pub use aggregator::{
     AggregatedMetricsMap, AggregationBatcher, Aggregator, DimensionPosition,
     DimensionedMeasurementsMap, DistributionMode, MeasurementAggregationMap, TimeSource,
 };
+pub use lambda::{lambda_metrics, LambdaFlusher, LambdaSink};
 pub use logging_sink::LoggingSink;
 pub use serializing_sink::SerializingSink;
 pub use stream_sink::StreamSink;


### PR DESCRIPTION
Currently, we don't have any support for using goodmetrics in lambda's, we are depending on our CW -> Chronosphere conversions which makes the whole metrics on lambda's a very cumbersome process.

To support this, we will need a non preaggregation configuration for a lambda pipeline. Ideally we'd send each metric immediately as a unary call, like the Kotlin implementation. But that doesn't fit cleanly in goodmetrics_rs as it records on a synchronous Drop, so there's no place to await a send inline. Instead, each recorded metric is converted by an unaggregated batcher into its own batch and buffered; the caller `flush()` on completion of the invocation, which sends the buffered metrics before the environment freezes.

I've created a test lambda which uses this version of goodmetrics_rs, it simply ran for 10 mins all while sending a heartbeat every ten seconds
<img width="1306" height="428" alt="image" src="https://github.com/user-attachments/assets/a50fba64-36c1-4e65-a924-5269c9ba21d5" />
